### PR TITLE
Use of --hex command line arg doesn't require also specifying --autoRun

### DIFF
--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -58,6 +58,9 @@ namespace FoenixIDE.UI
 
         public MainWindow(Dictionary<string, string> context)
         {
+            bool autoRunCommandLineSpecified = false;
+            bool boardVersionCommandLineSpecified = false;
+            
             if (context != null)
             {
                 if (context.ContainsKey("jumpStartAddress"))
@@ -71,6 +74,7 @@ namespace FoenixIDE.UI
                 if (context.ContainsKey("autoRun"))
                 {
                     autoRun = "true".Equals(context["autoRun"]);
+                    autoRunCommandLineSpecified = true;
                 }
                 if (context.ContainsKey("disabledIRQs"))
                 {
@@ -90,12 +94,16 @@ namespace FoenixIDE.UI
                     {
                         version = BoardVersion.RevUPlus;
                     }
+                    boardVersionCommandLineSpecified = true;
                 }
             }
             // If the user didn't specify context switches, read the ini setting
-            if (context == null)
+            if (!autoRunCommandLineSpecified)
             {
                 autoRun = Simulator.Properties.Settings.Default.Autorun;
+            }
+            if (!boardVersionCommandLineSpecified)
+            {
                 switch (Simulator.Properties.Settings.Default.BoardRevision)
                 {
                     case "B":


### PR DESCRIPTION
Repro:
1. Run "FoenixIDE.exe"
2. In the UI, disable autoRun.
3. Close emulator (.ini file gets saved).
4. Run "FoenixIDE.exe --hex someKernel.hex"

Expected: Emulator launches without autoRun
Actual: Emulator launches with autoRun

Explanation: if you use any command line switch (e.g., --hex) then the emulator looks for autoRun in the command line too.
If you don't specify autoRun on the command line, it won't fall back to reading it from the .ini file. Instead. autoRun always stays at the default (true).