### PR TITLE
Add support for 65816-based F256

### DIFF
--- a/Main/Devices/BoardVersion.cs
+++ b/Main/Devices/BoardVersion.cs
@@ -12,6 +12,15 @@ namespace FoenixIDE.Simulator.Devices
         RevC,
         RevU,
         RevUPlus,
-        RevJr
+        RevJr_6502,
+        RevJr_65816
+    }
+    
+    public static class BoardVersionHelpers
+    {
+        public static bool IsJr(BoardVersion boardVersion)
+        {
+            return boardVersion == BoardVersion.RevJr_6502 || boardVersion == BoardVersion.RevJr_65816;
+        }
     }
 }

--- a/Main/UI/CPUWindow.cs
+++ b/Main/UI/CPUWindow.cs
@@ -428,7 +428,7 @@ namespace FoenixIDE.UI
                 IRQPC = -1;
                 kernel.MemMgr.INTERRUPT.WriteFromGabe(0, 0);
                 kernel.MemMgr.INTERRUPT.WriteFromGabe(1, 0);
-                if (kernel.GetVersion() != BoardVersion.RevJr)
+                if (!BoardVersionHelpers.IsJr(kernel.GetVersion()))
                 {
                     kernel.MemMgr.INTERRUPT.WriteFromGabe(2, 0);
                     kernel.MemMgr.INTERRUPT.WriteFromGabe(3, 0);
@@ -952,7 +952,7 @@ namespace FoenixIDE.UI
                 if (KeyboardCheckBox.IsActive)
                     KeyboardCheckBox.IsActive = false;
             }
-            if (kernel.GetVersion() != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(kernel.GetVersion()))
             {
                 //Read Interrupt Register 2
                 byte reg2 = kernel.MemMgr.INTERRUPT.ReadByte(2);

--- a/Main/UI/MainWindow.Designer.cs
+++ b/Main/UI/MainWindow.Designer.cs
@@ -109,7 +109,7 @@ namespace FoenixIDE.UI
             this.toolStripRevision.BorderStyle = System.Windows.Forms.Border3DStyle.Sunken;
             this.toolStripRevision.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
             this.toolStripRevision.Name = "toolStripRevision";
-            this.toolStripRevision.Size = new System.Drawing.Size(64, 30);
+            this.toolStripRevision.Size = new System.Drawing.Size(100, 30);
             this.toolStripRevision.Text = "Rev B";
             this.toolStripRevision.ToolTipText = "Board Version";
             this.toolStripRevision.Click += new System.EventHandler(this.ToolStripRevision_Click);

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -93,7 +93,12 @@ namespace FoenixIDE.UI
                     }
                     else if (context["version"] == "RevJr")
                     {
-                        version = BoardVersion.RevJr;
+                        // Keep back-compatibility with existing command line options.
+                        version = BoardVersion.RevJr_6502;
+                    }
+                    else if (context["version"] == "RevJr816")
+                    {
+                        version = BoardVersion.RevJr_65816;
                     }
                     boardVersionCommandLineSpecified = true;
                 }
@@ -120,7 +125,10 @@ namespace FoenixIDE.UI
                         version = BoardVersion.RevUPlus;
                         break;
                     case "Jr":
-                        version = BoardVersion.RevJr;
+                        version = BoardVersion.RevJr_6502;
+                        break;
+                    case "Jr816":
+                        version = BoardVersion.RevJr_65816;
                         break;
                 }
             }
@@ -140,7 +148,8 @@ namespace FoenixIDE.UI
                     case BoardVersion.RevUPlus:
                         defaultKernel = @"roms\\kernel_U_Plus.hex";
                         break;
-                    case BoardVersion.RevJr:
+                    case BoardVersion.RevJr_6502:
+                    case BoardVersion.RevJr_65816: // Both SKUs share the same kernelfile
                         defaultKernel = @"roms\\kernel_F256Jr.hex";
                         break;
                 }
@@ -173,7 +182,7 @@ namespace FoenixIDE.UI
                 gpu.GpuUpdated += Gpu_Update_Cps_Fps;
             }
             gpu.VICKY = kernel.MemMgr.VICKY;
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 gpu.SetMode(0);
                 gpu.VRAM = kernel.MemMgr.VIDEO;
@@ -253,7 +262,7 @@ namespace FoenixIDE.UI
             }
 
             SetDipSwitchMemory();
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 // Code is tightly coupled with memory manager
                 kernel.MemMgr.UART1.TransmitByte += SerialTransmitByte;
@@ -431,7 +440,7 @@ namespace FoenixIDE.UI
         {
             // Check if the interrupt is enabled
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 // we need to this to avoid using the MMU IO Paging function
                 mask = kernel.MemMgr.VICKY.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR - 0xC000);
@@ -441,7 +450,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SOF Interrupt
                 byte IRQ0 = kernel.MemMgr.INTERRUPT.ReadByte(0);
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     // we need to this to avoid using the MMU IO Paging function
                     IRQ0 = kernel.MemMgr.VICKY.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR - 0xC000);
@@ -459,7 +468,7 @@ namespace FoenixIDE.UI
         {
             // Check if the interrupt is enabled
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR);
             }
@@ -468,7 +477,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SOL Interrupt
                 byte IRQ0 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0);
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     IRQ0 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR - 0xC000);
                 }
@@ -487,7 +496,7 @@ namespace FoenixIDE.UI
         {
             // Check if the SD Card interrupt is allowed
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG1);
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR + 1);
             }
@@ -495,7 +504,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SD Card Interrupt
                 byte IRQ1 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG1);
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     IRQ1 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR + 1);
                 }
@@ -588,7 +597,7 @@ namespace FoenixIDE.UI
 
         private void WriteKeyboardCode(ScanCode sc)
         {
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 // Check if the Keyboard interrupt is allowed
                 byte mask = kernel.MemMgr.ReadByte(MemoryMap.INT_MASK_REG1);
@@ -615,7 +624,7 @@ namespace FoenixIDE.UI
         }
         private void TriggerKeyboardInterrupt()
         {
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 // Set the Keyboard Interrupt
                 byte IrqVal = kernel.MemMgr.INTERRUPT.ReadByte(1);
@@ -635,7 +644,7 @@ namespace FoenixIDE.UI
 
         private void TriggerMouseInterrupt()
         {
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 // Set the Mouse Interrupt
                 byte IRQ0 = kernel.MemMgr.INTERRUPT.ReadByte(0);
@@ -764,7 +773,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     // Now update other registers
                     //kernel.MemMgr.MMU.Reset();
@@ -792,7 +801,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     // Now update other registers
                     kernel.MemMgr.MMU.Reset();
@@ -817,7 +826,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (version == BoardVersion.RevJr)
+                if (BoardVersionHelpers.IsJr(version))
                 {
                     // Now update other registers
                     kernel.MemMgr.MMU.Reset();
@@ -921,7 +930,7 @@ namespace FoenixIDE.UI
                     debugWindow.Pause();
                     SetDipSwitchMemory();
                     ShowDebugWindow();
-                    if (version == BoardVersion.RevJr)
+                    if (BoardVersionHelpers.IsJr(version))
                     {
                         // Now update other registers
                         kernel.MemMgr.MMU.Reset();
@@ -1003,7 +1012,7 @@ namespace FoenixIDE.UI
         {
             gpu.TileEditorMode = false;
             // Restore the previous graphics mode
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 kernel.MemMgr.VICKY.WriteByte(0, previousGraphicMode);
             }
@@ -1025,7 +1034,7 @@ namespace FoenixIDE.UI
                 tileEditor.SetResourceChecker(kernel.ResCheckerRef);
                 gpu.TileEditorMode = true;
                 // Set Vicky into Tile mode
-                if (version != BoardVersion.RevJr)
+                if (!BoardVersionHelpers.IsJr(version))
                 {
                     previousGraphicMode = kernel.MemMgr.VICKY.ReadByte(0);
                     kernel.MemMgr.VICKY.WriteByte(0, 0x10);
@@ -1065,13 +1074,13 @@ namespace FoenixIDE.UI
         private void Gpu_MouseMove(object sender, MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 size = gpu.GetScreenSize_JR();
             }
             float ratioW = gpu.Width / (float)size.X;
             float ratioH = gpu.Height / (float)size.Y;
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 bool borderEnabled = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.BORDER_CTRL_REG) == 1;
                 double borderWidth = borderEnabled ? kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.BORDER_X_SIZE) : 0;
@@ -1099,7 +1108,7 @@ namespace FoenixIDE.UI
         private void Gpu_MouseDown(object sender, MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 size = gpu.GetScreenSize_JR();
             }
@@ -1157,7 +1166,7 @@ namespace FoenixIDE.UI
         private void GenerateMouseInterrupt(MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (version == BoardVersion.RevJr)
+            if (BoardVersionHelpers.IsJr(version))
             {
                 gpu.GetScreenSize_JR();
             }
@@ -1186,7 +1195,7 @@ namespace FoenixIDE.UI
             left = false;
             right = false;
             middle = false;
-            if (version != BoardVersion.RevJr && gpu.IsMousePointerVisible() || gpu.TileEditorMode)
+            if (!BoardVersionHelpers.IsJr(version) && gpu.IsMousePointerVisible() || gpu.TileEditorMode)
             {
                 Cursor.Show();
             }
@@ -1195,7 +1204,7 @@ namespace FoenixIDE.UI
 
         private void Gpu_MouseEnter(object sender, EventArgs e)
         {
-            if (version != BoardVersion.RevJr && gpu.IsMousePointerVisible() && !gpu.TileEditorMode)
+            if (!BoardVersionHelpers.IsJr(version) && gpu.IsMousePointerVisible() && !gpu.TileEditorMode)
             {
                 Cursor.Hide();
             }
@@ -1286,11 +1295,17 @@ namespace FoenixIDE.UI
                 toolStripRevision.Text = "Rev U+";
                 shortVersion = "U+";
             }
-            else
+            else if (version == BoardVersion.RevJr_6502)
             {
                 toolStripRevision.Text = "Rev F256Jr";
                 shortVersion = "Jr";
             }
+            else if (version == BoardVersion.RevJr_65816)
+            {
+                toolStripRevision.Text = "Rev F256Jr(816)";
+                shortVersion = "Jr(816)";
+            }
+
             // force repaint
             statusStrip1.Invalidate();
             Simulator.Properties.Settings.Default.BoardRevision = shortVersion;
@@ -1317,7 +1332,12 @@ namespace FoenixIDE.UI
             }
             else if (version == BoardVersion.RevUPlus)
             {
-                version = BoardVersion.RevJr;
+                version = BoardVersion.RevJr_6502;
+                defaultKernel = @"roms\\kernel_F256Jr.hex";
+            }
+            else if (version == BoardVersion.RevJr_6502)
+            {
+                version = BoardVersion.RevJr_65816;
                 defaultKernel = @"roms\\kernel_F256Jr.hex";
             }
             else
@@ -1407,7 +1427,7 @@ namespace FoenixIDE.UI
 
         private void SetDipSwitchMemory()
         {
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 // if kernel memory is available, set the memory
                 byte bootMode = (byte)((switches[0] ? 0 : 1) + (switches[1] ? 0 : 2));
@@ -1465,7 +1485,7 @@ namespace FoenixIDE.UI
 
         public void WriteMCRBytesToVicky(byte low, byte high)
         {
-            int baseAddr = version == BoardVersion.RevJr ? 0xD000 - 0xC000 : 0;
+            int baseAddr = BoardVersionHelpers.IsJr(version) ? 0xD000 - 0xC000 : 0;
 
             kernel.MemMgr.VICKY.WriteByte(baseAddr, low);
             kernel.MemMgr.VICKY.WriteByte(baseAddr + 1, high);
@@ -1473,12 +1493,12 @@ namespace FoenixIDE.UI
 
         public ushort ReadMCRBytesFromVicky()
         {
-            return (ushort)kernel.MemMgr.VICKY.ReadWord(version == BoardVersion.RevJr ? 0xD000 - 0xC000 : 0);
+            return (ushort)kernel.MemMgr.VICKY.ReadWord(BoardVersionHelpers.IsJr(version) ? 0xD000 - 0xC000 : 0);
         }
 
         public void UpdateGamma(bool gamma)
         {
-            if (version != BoardVersion.RevJr)
+            if (!BoardVersionHelpers.IsJr(version))
             {
                 switches[6] = gamma;
                 dipSwitch.Invalidate();

--- a/Main/UI/UploaderWindow.cs
+++ b/Main/UI/UploaderWindow.cs
@@ -42,8 +42,11 @@ namespace FoenixIDE.UI
                 case BoardVersion.RevUPlus:
                     RevModeLabel.Text = "Mode: RevU+";
                     break;
-                case BoardVersion.RevJr:
+                case BoardVersion.RevJr_6502:
                     RevModeLabel.Text = "Mode: F256Jr";
+                    break;
+                case BoardVersion.RevJr_65816:
+                    RevModeLabel.Text = "Mode: F256Jr(816)";
                     break;
             }
         }
@@ -269,7 +272,7 @@ namespace FoenixIDE.UI
             {
                 BaseBankAddress = 0x18_0000;
             }
-            else if (boardVersion == BoardVersion.RevJr)
+            else if (BoardVersionHelpers.IsJr(boardVersion))
             {
                 BaseBankAddress = 0;
             }
@@ -775,7 +778,7 @@ namespace FoenixIDE.UI
             // Maximum transmission size is 8192
             if (Size > 8192)
             {
-                if (boardVersion != BoardVersion.RevJr)
+                if (!BoardVersionHelpers.IsJr(boardVersion))
                 {
                     Size = 8192;
                     Console.WriteLine("PreparePacket2Write: output truncated to 8K bytes.");


### PR DESCRIPTION
This change adds support for 65816-based F256 Jr, while maintaining support as well for 6502-based F256 Jr. The two varieties are similar, the 816-based one gives access to an expanded set of opcodes.

Example of successfully running 816-based code:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/16c02cb8-c149-4976-8436-12b2faf27b12)
