### PR TITLE
Add F256K matrix keyboard support

### DIFF
--- a/Main/Devices/MatrixKeyboardRegister.cs
+++ b/Main/Devices/MatrixKeyboardRegister.cs
@@ -1,0 +1,405 @@
+﻿using FoenixIDE.Basic;
+
+namespace FoenixIDE.Simulator.Devices
+{
+
+    public class MatrixKeyboardRegister
+    {
+        public class VIA0Range : MemoryLocations.MemoryRAM
+        {
+            public VIA0Range(int StartAddress, int Length) : base(StartAddress, Length)
+            {
+                System.Diagnostics.Debug.Assert(Length == 4);
+            }
+
+            bool CanRead(int Address)
+            {
+                if (Address == 0) // Port B
+                {
+                    bool canReadPortB = VIA0_DDRB == 0;
+                    return canReadPortB;
+                }
+                else if (Address == 1) // Port A
+                {
+                    bool canReadPortA = VIA0_DDRA == 0;
+                    return canReadPortA;
+                }
+                return true;
+            }
+
+
+            public override byte ReadByte(int Address)
+            {
+                if (!CanRead(Address))
+                    return 0;
+
+                byte read = data[Address];
+
+                if (Address == 0)
+                    VIA0_PRB = 0x7f; // For some reason I noticed programs depend on this side effect.
+
+                return read;
+            }
+
+            bool CanWrite(int Address)
+            {
+                if (Address == 0)
+                {
+                    bool canWritePortB = VIA0_DDRB == 0x7F;
+                    return canWritePortB;
+                }
+                if (Address == 1)
+                {
+                    bool canWritePortA = VIA0_DDRA == 0x7F;
+                    return canWritePortA;
+                }
+                return true;
+            }
+
+            public override void WriteByte(int Address, byte Value)
+            {
+                if (!CanWrite(Address))
+                    return;
+
+                data[Address] = Value;
+            }
+            public byte VIA0_PRB { get { return data[0]; } set { data[0] = value; } }
+            byte VIA0_DDRA { get { return data[3]; } set { data[3] = value; } }
+            byte VIA0_DDRB { get { return data[2]; } set { data[2] = value; } }
+        }
+
+        public class VIA1Range : MemoryLocations.MemoryRAM
+        {
+            public VIA1Range(MatrixKeyboardRegister m, int StartAddress, int Length) : base(StartAddress, Length)
+            {
+                System.Diagnostics.Debug.Assert(Length == 4);
+                matrix = m;
+            }
+
+            bool CanWrite(int Address)
+            {
+                if (Address == 0)
+                {
+                    bool canWritePortB = VIA1_DDRB == 0xFF;
+                    return canWritePortB;
+                }
+                if (Address == 1)
+                {
+                    bool canWritePortA = VIA1_DDRA == 0xFF;
+                    return canWritePortA;
+                }
+                return true;
+            }
+
+            public override void WriteByte(int Address, byte Value)
+            {
+                if (!CanWrite(Address))
+                    return;
+
+                data[Address] = Value;
+
+                HandleWriteSideEffects(Address, Value);
+            }
+
+            void HandleWriteSideEffects(int Address, byte Value)
+            {
+                if (Address == 1) // We wrote to port A.
+                {
+                    WriteByteSideEffect_StandardDirection(Value);
+                }
+                else if (Address == 0) // We wrote to port B.
+                {
+                    WriteByteSideEffect_ReverseDirection(Value);
+                }
+            }
+
+            public void WriteByteSideEffect_StandardDirection(byte Value)
+            {
+                if (Value == (1 << 0 ^ 0xFF)) // PA0
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= (1 << 0); // delete key, unmapped
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_enter] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_left_arrow] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_F7] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_F1] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_F3] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_F5] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_up_arrow] ? (byte)0 : (byte)(1 << 7);
+
+                    // Also set VIA0
+                    matrix.VIA0.VIA0_PRB = 0;
+                    matrix.VIA0.VIA0_PRB |= (1 << 0);
+                    matrix.VIA0.VIA0_PRB |= (1 << 1);
+                    matrix.VIA0.VIA0_PRB |= (1 << 2);
+                    matrix.VIA0.VIA0_PRB |= (1 << 3);
+                    matrix.VIA0.VIA0_PRB |= (1 << 4);
+                    matrix.VIA0.VIA0_PRB |= (1 << 5);
+                    matrix.VIA0.VIA0_PRB |= (1 << 6);
+                    matrix.VIA0.VIA0_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_down_arrow] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 1 ^ 0xFF)) // PA1
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_3] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_w] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_a] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_4] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_z] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_s] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_e] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_shiftLeft] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 2 ^ 0xFF)) // PA2
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_5] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_r] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_d] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_6] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_c] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_f] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_t] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_x] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 3 ^ 0xFF)) // PA3
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_7] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_y] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_g] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_8] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_b] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_h] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_u] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_v] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 4 ^ 0xFF)) // PA4
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_9] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_i] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_j] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_0] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_m] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_k] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_o] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_n] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 5 ^ 0xFF)) // PA5
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_minus] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_p] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_l] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_capslock] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_period] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_semicolon] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_bracketLeft] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_comma] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 6 ^ 0xFF)) // PA6
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_equals] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_bracketRight] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_apostrophe] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_backslash] ? (byte)0 : (byte)(1 << 3); // A backslash\ is mapped to the HOME key
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_shiftRight] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_altLeft] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_tab] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_slash] ? (byte)0 : (byte)(1 << 7);
+
+                    matrix.VIA0.VIA0_PRB = 0;
+                    matrix.VIA0.VIA0_PRB |= (1 << 0);
+                    matrix.VIA0.VIA0_PRB |= (1 << 1);
+                    matrix.VIA0.VIA0_PRB |= (1 << 2);
+                    matrix.VIA0.VIA0_PRB |= (1 << 3);
+                    matrix.VIA0.VIA0_PRB |= (1 << 4);
+                    matrix.VIA0.VIA0_PRB |= (1 << 5);
+                    matrix.VIA0.VIA0_PRB |= (1 << 6);
+                    matrix.VIA0.VIA0_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_right_arrow] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 7 ^ 0xFF)) // PA7
+                {
+                    VIA1_PRB = 0;
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_1] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_backspace] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_controlLeft] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_2] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_space] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_grave] ? (byte)0 : (byte)(1 << 5); // A backtick` is mapped to the Foenix key
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_q] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRB |= matrix.scanCodeBuffer[(int)ScanCode.sc_escape] ? (byte)0 : (byte)(1 << 7); // Escape is mapped to RUN/STOP
+                }
+                else
+                {
+                    VIA1_PRB = 0xFF;
+                }
+            }
+
+            public void WriteByteSideEffect_ReverseDirection(byte Value)
+            {
+                // I noticed VIA0 isn't accessible when using the reverse direction on HW, so it is not updated here.
+
+                if (Value == (1 << 0 ^ 0xFF)) // PB0
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= (1 << 0); // delete key, unmapped
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_3] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_5] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_7] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_9] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_minus] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_equals] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_1] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 1 ^ 0xFF)) // PB1
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_enter] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_w] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_r] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_y] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_i] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_p] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_bracketRight] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_backspace] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 2 ^ 0xFF)) // PB2
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_left_arrow] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_a] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_d] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_g] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_j] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_l] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_semicolon] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_controlLeft] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 3 ^ 0xFF)) // PB3
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_F7] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_4] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_6] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_8] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_0] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_capslock] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_backslash] ? (byte)0 : (byte)(1 << 6);  // A backslash\ is mapped to the HOME key
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_2] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 4 ^ 0xFF)) // PB4
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_F1] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_z] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_c] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_b] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_m] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_period] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_shiftRight] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_space] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 5 ^ 0xFF)) // PB5
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_F3] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_s] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_f] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_h] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_k] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_apostrophe] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_altLeft] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_grave] ? (byte)0 : (byte)(1 << 7); // A backtick` is mapped to the Foenix key
+                }
+                else if (Value == (1 << 6 ^ 0xFF)) // PB6
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_F5] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_e] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_t] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_u] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_o] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_bracketLeft] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_tab] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_q] ? (byte)0 : (byte)(1 << 7);
+                }
+                else if (Value == (1 << 7 ^ 0xFF)) // PB7
+                {
+                    VIA1_PRA = 0;
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_up_arrow] ? (byte)0 : (byte)(1 << 0);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_shiftLeft] ? (byte)0 : (byte)(1 << 1);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_x] ? (byte)0 : (byte)(1 << 2);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_v] ? (byte)0 : (byte)(1 << 3);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_n] ? (byte)0 : (byte)(1 << 4);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_comma] ? (byte)0 : (byte)(1 << 5);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_slash] ? (byte)0 : (byte)(1 << 6);
+                    VIA1_PRA |= matrix.scanCodeBuffer[(int)ScanCode.sc_escape] ? (byte)0 : (byte)(1 << 7);  // Escape is mapped to RUN/STOP
+                }
+                else
+                {
+                    VIA1_PRB = 0xFF;
+                }
+            }
+
+            bool CanRead(int Address)
+            {
+                if (Address == 0) // Port B
+                {
+                    bool canReadPortB = VIA1_DDRB == 0;
+                    return canReadPortB;
+                }
+                else if (Address == 1) // Port A
+                {
+                    bool canReadPortA = VIA1_DDRA == 0;
+                    return canReadPortA;
+                }
+                return true;
+            }
+
+            public override byte ReadByte(int Address)
+            {
+                if (!CanRead(Address))
+                    return 0;
+
+                return data[Address];
+            }
+            byte VIA1_PRA { get { return data[1]; } set { data[1] = value; } }
+            byte VIA1_PRB { get { return data[0]; } set { data[0] = value; } }
+
+            byte VIA1_DDRA { get { return data[3]; } set { data[3] = value; } }
+            byte VIA1_DDRB { get { return data[2]; } set { data[2] = value; } }
+
+            MatrixKeyboardRegister matrix;
+        }
+
+        public MatrixKeyboardRegister(int Range0StartAddress, int Range0Length, int Range1StartAddress, int Range1Length)
+        {
+            System.Diagnostics.Debug.Assert(Range0Length == 4);
+            scanCodeBuffer = new bool[(int)ScanCode.sc_down_arrow + 1];
+            VIA0 = new VIA0Range(Range0StartAddress, Range0Length);
+            VIA1 = new VIA1Range(this, Range1StartAddress, Range1Length);
+        }
+
+        public VIA0Range VIA0; // Used for the right and down arrow keys
+        public VIA1Range VIA1; // Used for all the other keys
+
+        public void WriteScanCode(ScanCode sc)
+        {
+            int scn = (int)sc;
+
+            if (scn < scanCodeBuffer.Length)
+            {
+                scanCodeBuffer[scn] = true;
+            }
+            else
+            {
+                scn -= 0x80;
+                scanCodeBuffer[scn] = false;
+            }
+        }
+        bool[] scanCodeBuffer;
+    }
+}

--- a/Main/Devices/PS2KeyboardRegister.cs
+++ b/Main/Devices/PS2KeyboardRegister.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace FoenixIDE.Simulator.Devices
 {
-    public class KeyboardRegister: MemoryLocations.MemoryRAM
+    public class PS2KeyboardRegister: MemoryLocations.MemoryRAM
     {
         private bool mouseDevice = false;
         private bool breakKey = false;
@@ -14,7 +14,7 @@ namespace FoenixIDE.Simulator.Devices
         public TriggerInterruptDelegate TriggerKeyboardInterrupt;
         public TriggerInterruptDelegate TriggerMouseInterrupt;
 
-        public KeyboardRegister(int StartAddress, int Length) : base(StartAddress, Length)
+        public PS2KeyboardRegister(int StartAddress, int Length) : base(StartAddress, Length)
         {
         }
 

--- a/Main/FoenixIDE.csproj
+++ b/Main/FoenixIDE.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Devices\GabeRAM.cs" />
     <Compile Include="Devices\InterruptController.cs" />
     <Compile Include="Devices\Interrupts.cs" />
+    <Compile Include="Devices\MatrixKeyboardRegister.cs" />
     <Compile Include="Devices\PS2KeyboardRegister.cs" />
     <Compile Include="Devices\MathFloatRegister.cs" />
     <Compile Include="Devices\RTC.cs" />

--- a/Main/FoenixIDE.csproj
+++ b/Main/FoenixIDE.csproj
@@ -92,7 +92,7 @@
     <Compile Include="Devices\GabeRAM.cs" />
     <Compile Include="Devices\InterruptController.cs" />
     <Compile Include="Devices\Interrupts.cs" />
-    <Compile Include="Devices\KeyboardRegister.cs" />
+    <Compile Include="Devices\PS2KeyboardRegister.cs" />
     <Compile Include="Devices\MathFloatRegister.cs" />
     <Compile Include="Devices\RTC.cs" />
     <Compile Include="Devices\TimerRegister.cs" />

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -95,7 +95,7 @@ namespace FoenixIDE
 
                     // Special devices
                     MATH = new MathCoproRegister(MemoryMap.MATH_START, MemoryMap.MATH_END - MemoryMap.MATH_START + 1), // 48 bytes
-                    KEYBOARD = new KeyboardRegister(keyboardAddress, 5),
+                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
                     SDCARD = sdcard,
                     INTERRUPT = new InterruptController(MemoryMap.INT_PENDING_REG0, 4),
                     UART1 = new UART(MemoryMap.UART1_REGISTERS, 8),
@@ -124,7 +124,7 @@ namespace FoenixIDE
                     RAM = new MemoryRAM(MemoryMap.RAM_START, memSize),
                     // vicky will store 4 pages of data
                     VICKY = new MemoryRAM(0, 4 * 0x2000),
-                    KEYBOARD = new KeyboardRegister(keyboardAddress, 5),
+                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
                     MATH = new MathCoproRegister(MemoryMap.MATH_START_JR, MemoryMap.MATH_END_JR - MemoryMap.MATH_START_JR + 1), // 32 bytes
                     SDCARD = sdcard,
                     INTERRUPT = new InterruptController(MemoryMap.INT_PENDING_REG0_JR, 2),
@@ -550,9 +550,9 @@ namespace FoenixIDE
             }
             CPU.Reset();
 
-            // Reset the keyboard
-            MemMgr.KEYBOARD.WriteByte(0, 0);
-            MemMgr.KEYBOARD.WriteByte(4, 0);
+            // Reset the keyboards
+            MemMgr.PS2KEYBOARD.WriteByte(0, 0);
+            MemMgr.PS2KEYBOARD.WriteByte(4, 0);
 
             return true;
         }

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -125,6 +125,7 @@ namespace FoenixIDE
                     // vicky will store 4 pages of data
                     VICKY = new MemoryRAM(0, 4 * 0x2000),
                     PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
+                    MATRIXKEYBOARD = new MatrixKeyboardRegister(MemoryMap.MATRIX_KEYBOARD_VIA0_PORT_B, 4, MemoryMap.MATRIX_KEYBOARD_VIA1_PORT_B, 4),
                     MATH = new MathCoproRegister(MemoryMap.MATH_START_JR, MemoryMap.MATH_END_JR - MemoryMap.MATH_START_JR + 1), // 32 bytes
                     SDCARD = sdcard,
                     INTERRUPT = new InterruptController(MemoryMap.INT_PENDING_REG0_JR, 2),
@@ -553,6 +554,19 @@ namespace FoenixIDE
             // Reset the keyboards
             MemMgr.PS2KEYBOARD.WriteByte(0, 0);
             MemMgr.PS2KEYBOARD.WriteByte(4, 0);
+            
+            if (MemMgr.MATRIXKEYBOARD != null)
+            {
+                MemMgr.MATRIXKEYBOARD.VIA0.WriteByte(0, 0);
+                MemMgr.MATRIXKEYBOARD.VIA0.WriteByte(1, 0);
+                MemMgr.MATRIXKEYBOARD.VIA0.WriteByte(2, 0);
+                MemMgr.MATRIXKEYBOARD.VIA0.WriteByte(3, 0);
+
+                MemMgr.MATRIXKEYBOARD.VIA1.WriteByte(0, 0);
+                MemMgr.MATRIXKEYBOARD.VIA1.WriteByte(1, 0);
+                MemMgr.MATRIXKEYBOARD.VIA1.WriteByte(2, 0);
+                MemMgr.MATRIXKEYBOARD.VIA1.WriteByte(3, 0);
+            }
 
             return true;
         }

--- a/Main/MemoryLocations/MemoryManager.cs
+++ b/Main/MemoryLocations/MemoryManager.cs
@@ -29,7 +29,7 @@ namespace FoenixIDE.MemoryLocations
         public MathCoproRegister MATH = null;
         public MathFloatRegister FLOAT = null;
         public CodecRAM CODEC = null;
-        public KeyboardRegister KEYBOARD = null;
+        public PS2KeyboardRegister PS2KEYBOARD = null;
         public SDCardDevice SDCARD = null;
         public InterruptController INTERRUPT = null;
         public UART UART1 = null;
@@ -122,10 +122,10 @@ namespace FoenixIDE.MemoryLocations
                     return;
                 }
 
-                if (Address >= KEYBOARD.StartAddress && Address <= KEYBOARD.EndAddress)
+                if (Address >= PS2KEYBOARD.StartAddress && Address <= PS2KEYBOARD.EndAddress)
                 {
-                    Device = KEYBOARD;
-                    DeviceAddress = Address - KEYBOARD.StartAddress;
+                    Device = PS2KEYBOARD;
+                    DeviceAddress = Address - PS2KEYBOARD.StartAddress;
                     return;
                 }
                 if (Address >= UART1.StartAddress && Address <= UART1.EndAddress)
@@ -247,10 +247,10 @@ namespace FoenixIDE.MemoryLocations
                         DeviceAddress = Address - TIMER1.StartAddress;
                         return;
                     }
-                    if (Address >= KEYBOARD.StartAddress && Address <= KEYBOARD.EndAddress)
+                    if (Address >= PS2KEYBOARD.StartAddress && Address <= PS2KEYBOARD.EndAddress)
                     {
-                        Device = KEYBOARD;
-                        DeviceAddress = Address - KEYBOARD.StartAddress;
+                        Device = PS2KEYBOARD;
+                        DeviceAddress = Address - PS2KEYBOARD.StartAddress;
                         return;
                     }
                     if (Address >= UART1.StartAddress && Address <= UART1.EndAddress)

--- a/Main/MemoryLocations/MemoryManager.cs
+++ b/Main/MemoryLocations/MemoryManager.cs
@@ -30,6 +30,7 @@ namespace FoenixIDE.MemoryLocations
         public MathFloatRegister FLOAT = null;
         public CodecRAM CODEC = null;
         public PS2KeyboardRegister PS2KEYBOARD = null;
+        public MatrixKeyboardRegister MATRIXKEYBOARD = null;
         public SDCardDevice SDCARD = null;
         public InterruptController INTERRUPT = null;
         public UART UART1 = null;
@@ -127,6 +128,21 @@ namespace FoenixIDE.MemoryLocations
                     Device = PS2KEYBOARD;
                     DeviceAddress = Address - PS2KEYBOARD.StartAddress;
                     return;
+                }
+                if (MATRIXKEYBOARD != null)
+                {
+                    if (Address >= MATRIXKEYBOARD.VIA0.StartAddress && Address <= MATRIXKEYBOARD.VIA0.EndAddress)
+                    {
+                        Device = MATRIXKEYBOARD.VIA0;
+                        DeviceAddress = Address - MATRIXKEYBOARD.VIA0.StartAddress;
+                        return;
+                    }
+                    if (Address >= MATRIXKEYBOARD.VIA1.StartAddress && Address <= MATRIXKEYBOARD.VIA1.EndAddress)
+                    {
+                        Device = MATRIXKEYBOARD.VIA1;
+                        DeviceAddress = Address - MATRIXKEYBOARD.VIA1.StartAddress;
+                        return;
+                    }
                 }
                 if (Address >= UART1.StartAddress && Address <= UART1.EndAddress)
                 {
@@ -252,6 +268,21 @@ namespace FoenixIDE.MemoryLocations
                         Device = PS2KEYBOARD;
                         DeviceAddress = Address - PS2KEYBOARD.StartAddress;
                         return;
+                    }
+                    if (MATRIXKEYBOARD != null)
+                    {
+                        if (Address >= MATRIXKEYBOARD.VIA0.StartAddress && Address <= MATRIXKEYBOARD.VIA0.EndAddress)
+                        {
+                            Device = MATRIXKEYBOARD.VIA0;
+                            DeviceAddress = Address - MATRIXKEYBOARD.VIA0.StartAddress;
+                            return;
+                        }
+                        if (Address >= MATRIXKEYBOARD.VIA1.StartAddress && Address <= MATRIXKEYBOARD.VIA1.EndAddress)
+                        {
+                            Device = MATRIXKEYBOARD.VIA1;
+                            DeviceAddress = Address - MATRIXKEYBOARD.VIA1.StartAddress;
+                            return;
+                        }
                     }
                     if (Address >= UART1.StartAddress && Address <= UART1.EndAddress)
                     {

--- a/Main/MemoryLocations/MemoryMap_Page00.cs
+++ b/Main/MemoryLocations/MemoryMap_Page00.cs
@@ -161,6 +161,16 @@ namespace FoenixIDE.MemoryLocations
         //// public const int KEYBOARD_SC_FLG = 0X000F43; // 1 Bytes that indicate the Status of Left Shift, Left CTRL, Left ALT, Right Shift
         //// public const int KEYBOARD_SC_TMP = 0X000F44; // 1 Byte, Interrupt Save Scan Code while Processing
 
+        public const int MATRIX_KEYBOARD_VIA0_PORT_B = 0xDC00;
+        public const int MATRIX_KEYBOARD_VIA0_PORT_A = 0xDC01;
+        public const int MATRIX_KEYBOARD_VIA0_DATA_DIRECTION_B = 0xDC02;
+        public const int MATRIX_KEYBOARD_VIA0_DATA_DIRECTION_A = 0xDC03;
+
+        public const int MATRIX_KEYBOARD_VIA1_PORT_B = 0xDB00;
+        public const int MATRIX_KEYBOARD_VIA1_PORT_A = 0xDB01;
+        public const int MATRIX_KEYBOARD_VIA1_DATA_DIRECTION_B = 0xDB02;
+        public const int MATRIX_KEYBOARD_VIA1_DATA_DIRECTION_A = 0xDB03;
+
         public const int TEST_BEGIN = 0x001000; // 28672 Bytes Test/diagnostic code for prototype.
         public const int TEST_END = 0x007FFF; // 0 Byte 
 

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -271,8 +271,8 @@ namespace FoenixIDE.UI
                 kernel.MemMgr.UART2.TransmitByte += SerialTransmitByte;
             }
             kernel.MemMgr.SDCARD.sdCardIRQMethod += SDCardInterrupt;
-            kernel.MemMgr.KEYBOARD.TriggerMouseInterrupt += TriggerMouseInterrupt;
-            kernel.MemMgr.KEYBOARD.TriggerKeyboardInterrupt += TriggerKeyboardInterrupt;
+            kernel.MemMgr.PS2KEYBOARD.TriggerMouseInterrupt += TriggerMouseInterrupt;
+            kernel.MemMgr.PS2KEYBOARD.TriggerKeyboardInterrupt += TriggerKeyboardInterrupt;
 
             kernel.ResCheckerRef = ResChecker;
 
@@ -593,7 +593,7 @@ namespace FoenixIDE.UI
                 e.Handled = true;
                 if (kernel.MemMgr != null && !kernel.CPU.DebugPause)
                 {
-                    kernel.MemMgr.KEYBOARD.WriteScanCodeSequence(new byte[] { 0xe1, 0x1d, 0x45, 0xe1, 0x9d, 0xc5 }, 6);
+                    kernel.MemMgr.PS2KEYBOARD.WriteScanCodeSequence(new byte[] { 0xe1, 0x1d, 0x45, 0xe1, 0x9d, 0xc5 }, 6);
                 }
                 lastKeyPressed.Text = "Break";
             }
@@ -611,8 +611,8 @@ namespace FoenixIDE.UI
                 byte mask = kernel.MemMgr.ReadByte(MemoryMap.INT_MASK_REG1);
                 if ((~mask & (byte)Register1.FNX1_INT00_KBD) != 0)
                 {
-                    kernel.MemMgr.KEYBOARD.WriteByte(0, (byte)sc);
-                    kernel.MemMgr.KEYBOARD.WriteByte(4, 0);
+                    kernel.MemMgr.PS2KEYBOARD.WriteByte(0, (byte)sc);
+                    kernel.MemMgr.PS2KEYBOARD.WriteByte(4, 0);
 
                     TriggerKeyboardInterrupt();
                 }
@@ -623,8 +623,8 @@ namespace FoenixIDE.UI
                 byte mask = kernel.MemMgr.VICKY.ReadByte(MemoryMap.INT_MASK_REG0_JR - 0xC000);
                 if ((~mask & (byte)Register0_JR.JR0_INT02_KBD) != 0)
                 {
-                    kernel.MemMgr.KEYBOARD.WriteByte(0, (byte)sc);
-                    kernel.MemMgr.KEYBOARD.WriteByte(4, 0);
+                    kernel.MemMgr.PS2KEYBOARD.WriteByte(0, (byte)sc);
+                    kernel.MemMgr.PS2KEYBOARD.WriteByte(4, 0);
 
                     TriggerKeyboardInterrupt();
                 }
@@ -1194,7 +1194,7 @@ namespace FoenixIDE.UI
             // The PS/2 packet is byte0, xm, ym
             if ((~mask & (byte)Register0.FNX0_INT07_MOUSE) == (byte)Register0.FNX0_INT07_MOUSE)
             {
-                kernel.MemMgr.KEYBOARD.MousePackets((byte)(8 + (middle ? 4 : 0) + (right ? 2 : 0) + (left ? 1 : 0)), (byte)(X & 0xFF), (byte)(Y & 0xFF));
+                kernel.MemMgr.PS2KEYBOARD.MousePackets((byte)(8 + (middle ? 4 : 0) + (right ? 2 : 0) + (left ? 1 : 0)), (byte)(X & 0xFF), (byte)(Y & 0xFF));
             }
         }
 

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -619,6 +619,12 @@ namespace FoenixIDE.UI
             }
             else
             {
+                // Notify the F256K matrix keyboard
+                if (kernel.MemMgr.MATRIXKEYBOARD != null)
+                {
+                    kernel.MemMgr.MATRIXKEYBOARD.WriteScanCode(sc);
+                }
+
                 // Check if the Keyboard interrupt is allowed
                 byte mask = kernel.MemMgr.VICKY.ReadByte(MemoryMap.INT_MASK_REG0_JR - 0xC000);
                 if ((~mask & (byte)Register0_JR.JR0_INT02_KBD) != 0)


### PR DESCRIPTION
This change contains
* Simple rename of "keyboard" to "PS2 keyboard" so that it's clear which keyboard it is
* Adds F256k matrix keyboard support.
* Included support for right and down arrow keys on the separate VIA

Tested applications:
* [keytest.hex](https://github.com/clandrew/fnxapp/blob/main/keytest/keytest.s)
* [allkeys.hex](https://github.com/clandrew/fnxapp/blob/main/allkeys/allkeys.s)
* OpenFNXKernel+basic, with some modifications provided by gadget

Demo screenshots:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/0779d9a4-7107-48a9-821d-71136b4a11f5)

![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/cee01695-dae6-4938-aee1-790f25874c68)

