### PR TITLE
Fix appearance of Autorun Emulator check box

### DIFF
--- a/Main/UI/MainWindow.Designer.cs
+++ b/Main/UI/MainWindow.Designer.cs
@@ -374,6 +374,7 @@ namespace FoenixIDE.UI
             this.autorunEmulatorToolStripMenuItem.Size = new System.Drawing.Size(180, 23);
             this.autorunEmulatorToolStripMenuItem.Text = "Autorun Emulator";
             this.autorunEmulatorToolStripMenuItem.Click += new System.EventHandler(this.AutorunEmulatorToolStripMenuItem_Click);
+            this.autorunEmulatorToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
             // 
             // windowsToolStripMenuItem
             // 


### PR DESCRIPTION
This is a small UI fixup that fixes the appearance of the check box for the "Autorun Emulator" check box.
Before:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/8949db70-56a0-40f7-9468-9eb4831537e6)

After:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/81b41908-e815-421b-9a3e-f83f70981541)

Confirmed with people on Discord that they repro the 'before' state too.
I'm led to believe the problem comes from buggy behavior in .NET layout, where SizeToFit will fit against something other than the displayed size. I checked the assigned size of the toolstrip and toolstrip menu item and they seem right or at least unrelated to the issue.