### PR TITLE
Remember the user's choices for SD card settings

### DIFF
--- a/Main/Properties/Settings.Designer.cs
+++ b/Main/Properties/Settings.Designer.cs
@@ -46,5 +46,76 @@ namespace FoenixIDE.Simulator.Properties {
                 this["BoardRevision"] = value;
             }
         }
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SDCardPath {
+            get {
+                return ((string)(this["SDCardPath"]));
+            }
+            set {
+                this["SDCardPath"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("64")]
+        public int SDCardCapacity
+        {
+            get
+            {
+                return ((int)(this["SDCardCapacity"]));
+            }
+            set
+            {
+                this["SDCardCapacity"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("512")]
+        public int SDCardClusterSize
+        {
+            get
+            {
+                return ((int)(this["SDCardClusterSize"]));
+            }
+            set
+            {
+                this["SDCardClusterSize"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("FAT32")]
+        public string SDCardFSType
+        {
+            get
+            {
+                return ((string)(this["SDCardFSType"]));
+            }
+            set
+            {
+                this["SDCardFSType"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool SDCardISOMode
+        {
+            get
+            {
+                return ((bool)(this["SDCardISOMode"]));
+            }
+            set
+            {
+                this["SDCardISOMode"] = value;
+            }
+        }
     }
 }

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -1235,17 +1235,25 @@ namespace FoenixIDE.UI
                 sdCardWindow.SetClusterSize(kernel.MemMgr.SDCARD.GetClusterSize());
                 sdCardWindow.SetFSType(kernel.MemMgr.SDCARD.GetFSType().ToString());
                 sdCardWindow.ShowDialog(this);
+
+                Simulator.Properties.Settings.Default.SDCardPath = sdCardWindow.GetPath();
+                Simulator.Properties.Settings.Default.SDCardCapacity = sdCardWindow.GetCapacity();
+                Simulator.Properties.Settings.Default.SDCardClusterSize = sdCardWindow.GetClusterSize();
+                Simulator.Properties.Settings.Default.SDCardFSType = sdCardWindow.GetFSType();
+                Simulator.Properties.Settings.Default.SDCardISOMode = sdCardWindow.GetISOMode();
+                Simulator.Properties.Settings.Default.Save();
+
                 ResetSDCard();
             }
         }
 
         private void ResetSDCard()
         {
-            string path = sdCardWindow.GetPath();
-            int capacity = sdCardWindow.GetCapacity();
-            int clusterSize = sdCardWindow.GetClusterSize();
-            string fsType = sdCardWindow.GetFSType();
-            bool ISOMode = sdCardWindow.GetISOMode();
+            string path = Simulator.Properties.Settings.Default.SDCardPath;
+            int capacity = Simulator.Properties.Settings.Default.SDCardCapacity;
+            int clusterSize = Simulator.Properties.Settings.Default.SDCardClusterSize;
+            string fsType = Simulator.Properties.Settings.Default.SDCardFSType;
+            bool ISOMode = Simulator.Properties.Settings.Default.SDCardISOMode;
 
             kernel.MemMgr.SDCARD.SetSDCardPath(path);
             byte sdCardStat = 0;

--- a/Main/UI/SDCardWindow.cs
+++ b/Main/UI/SDCardWindow.cs
@@ -65,7 +65,7 @@ namespace FoenixIDE.Simulator.UI
         // Virtual SD Card Capacity
         public void SetCapacity(int value)
         {
-            int index = CapacityCombo.Items.IndexOf(value);
+            int index = CapacityCombo.Items.IndexOf(value.ToString());
             if (index != -1)
             {
                 CapacityCombo.SelectedIndex = index;
@@ -79,7 +79,7 @@ namespace FoenixIDE.Simulator.UI
         // Virtual SD Card Cluster Size
         public void SetClusterSize(int value)
         {
-            int index = ClusterCombo.Items.IndexOf(value);
+            int index = ClusterCombo.Items.IndexOf(value.ToString());
             if (index != -1)
             {
                 ClusterCombo.SelectedIndex = index;


### PR DESCRIPTION
This change makes it so the options chosen in the SD card window persist if you restart the emulator. 

This is useful since the built-in folder picker UI on Windows is a bit cumbersome.

This change also fixes a bug where the SD card window wouldn't get populated correctly, because FoenixIDE.Simulator.UI.SDCardWindow.SetCapacity and SetClusterSize would always look for an int in a collection of strings and fail to find it.