### PR TITLE
Fix crash that can happen when using some cluster+capacity combinations on F256

### DIFF
--- a/Main/Devices/SDCard/F256SDController.cs
+++ b/Main/Devices/SDCard/F256SDController.cs
@@ -27,6 +27,8 @@ namespace FoenixIDE.Simulator.Devices
             public int WriteAddressInBytes;
             public List<byte> WriteBytes;
             public List<byte> DataResponseBytes;
+
+            public bool ReportError;
         }
         Command CurrentCommand;
 
@@ -159,6 +161,7 @@ namespace FoenixIDE.Simulator.Devices
 
                                 // Need to send response token now
                                 CurrentCommand.DataResponseBytes = new List<byte>();
+
                                 CurrentCommand.DataResponseBytes.Add(5);
                             }
                         }
@@ -374,6 +377,21 @@ namespace FoenixIDE.Simulator.Devices
                 return false;
 
             return true; 
+        }
+
+        protected override void ReportError()
+        {
+#if DEBUG
+            // TODO: Have reported errors be returned up as command codes. For now, this is a temporary measure to divert error handling
+            // from the GabeSDController path, since it returns errors through its memory-mapped register where there isn't an equivalent
+            // for this memory-mapped range.
+            System.Diagnostics.Debugger.Break();
+#endif
+            if (CurrentCommand != null)
+            {
+                CurrentCommand.ReportError = true;
+            }
+
         }
     }
 }

--- a/Main/Devices/SDCard/FakeFATSDCardDevice.cs
+++ b/Main/Devices/SDCard/FakeFATSDCardDevice.cs
@@ -433,7 +433,7 @@ namespace FoenixIDE.Simulator.Devices
                 catch (Exception e)
                 {
                     // controller error
-                    data[5] = 1;
+                    ReportError();
                     System.Console.WriteLine(e.ToString());
                     return null;
                 }
@@ -522,7 +522,7 @@ namespace FoenixIDE.Simulator.Devices
                     catch (Exception e)
                     {
                         // controller error
-                        data[5] = 1;
+                        ReportError();
                         System.Console.WriteLine(e.ToString());
                         return null;
                     }
@@ -740,7 +740,7 @@ namespace FoenixIDE.Simulator.Devices
                 catch (Exception e)
                 {
                     // controller error
-                    data[5] = 1;
+                    ReportError();
                     System.Console.WriteLine(e.ToString());
                     return;
                 }
@@ -803,9 +803,14 @@ namespace FoenixIDE.Simulator.Devices
                 {
                     // Invalid address
                     Console.WriteLine("Gabe is trying to write to an invalid address:" + writeAddress);
-                    data[5] = 1;
+                    ReportError();
                 }
             }
+        }
+
+        protected virtual void ReportError()
+        {
+            data[5] = 1;
         }
 
         protected virtual bool ShouldPreparePlaceholderFileEntry(int page)


### PR DESCRIPTION
This is a fix that works for now. It fixes a crash that can happen when using e.g., 8MB capacity 512 cluster size. The emulator would try to write to the same memory-mapped register as the C256 path (since they share much of the same code), which doesn't exist on F256.

In the future a better fix will be to really understand the communication between kernel and FAT, and why kernel is requesting what seems like out-of-bounds writes based on what's reported in the boot sector.