### PR TITLE
Correct number of Foenix versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more information on the project, go to [C256 Foenix Computer](https://www.c2
 
 The FoenixIDE is a work in progress.
 
-The C256 Foenix and its associated materials are owned by Stefany Allaire. There are three versions of the Foenix: 
+The C256 Foenix and its associated materials are owned by Stefany Allaire. There are several versions of the Foenix: 
 * RevB (2 MB RAM, 2xOPL2)  - Processor: 65816
 * RevC - aka FMX (4 MB RAM, OPL3, OPN2, OPM and SN76489)  - Processor: 65816
 * RevU - 1 MB RAM  - Processor: 65816


### PR DESCRIPTION
Update number of version from 'three' to 'several', since currently six versions are listed.