### PR TITLE
Add F256 RNG reg support

### DIFF
--- a/Main/Devices/RNGRegister.cs
+++ b/Main/Devices/RNGRegister.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FoenixIDE.Simulator.Devices
+{
+    // Used by F256.
+    public class RNGRegister : MemoryLocations.MemoryRAM
+    {
+        int seed;
+        bool enabled;
+        byte lastHigh;
+        byte lastLow;
+        Random random;
+
+        public RNGRegister(int StartAddress, int Length) : base(StartAddress, Length)
+        {
+            System.Diagnostics.Debug.Assert(Length == 3);
+            random = new Random(0);
+        }
+
+        byte NextRandomByte()
+        {
+            byte[] buf = new byte[1];
+            random.NextBytes(buf);
+            return buf[0];
+        }
+
+        public override byte ReadByte(int Address)
+        {
+            if (Address == 0) // rndl
+            {
+                if (enabled)
+                {
+                    lastLow = NextRandomByte();
+                }
+                return lastLow;
+            }
+
+            if (Address == 1) // rndh
+            {
+                if (enabled)
+                {
+                    lastHigh = NextRandomByte();
+                }
+                return lastHigh;
+            }
+
+            if (Address == 2) // rnd_stat
+            {
+                return 0xFF;
+            }
+
+            byte read = data[Address];
+            return read;
+        }
+
+        public override void WriteByte(int Address, byte Value)
+        {
+            if (Address == 0) // seedl
+            {
+                seed &= 0xFF00;
+                seed |= Value;
+            }
+            else if (Address == 1) // seedh
+            {
+                seed &= 0x00FF;
+                seed |= Value << 8;
+            }
+            else if (Address == 2) // rnd_ctrl
+            {
+                bool seedld = (Value & 0x2) != 0;
+                if (seedld)
+                {
+                    random = new Random(seed);
+                }
+
+                bool enable = (Value & 0x1) != 0;
+                enabled = enable;
+            }
+            data[Address] = Value;
+        }
+    }
+}

--- a/Main/Devices/RNGRegister.cs
+++ b/Main/Devices/RNGRegister.cs
@@ -18,7 +18,7 @@ namespace FoenixIDE.Simulator.Devices
         public RNGRegister(int StartAddress, int Length) : base(StartAddress, Length)
         {
             System.Diagnostics.Debug.Assert(Length == 3);
-            random = new Random(0);
+            random = new Random();
         }
 
         byte NextRandomByte()

--- a/Main/FoenixIDE.csproj
+++ b/Main/FoenixIDE.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Devices\MatrixKeyboardRegister.cs" />
     <Compile Include="Devices\PS2KeyboardRegister.cs" />
     <Compile Include="Devices\MathFloatRegister.cs" />
+    <Compile Include="Devices\RNGRegister.cs" />
     <Compile Include="Devices\RTC.cs" />
     <Compile Include="Devices\SDCard\F256SDController.cs" />
     <Compile Include="Devices\SDCard\FakeFATSDCardDevice.cs" />

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -130,7 +130,8 @@ namespace FoenixIDE
                     TIMER1 = new TimerRegister(MemoryMap.TIMER1_CTRL_REG_JR, 8),
                     RTC = new RTC(MemoryMap.RTC_SEC_JR, 16),
                     CODEC = codec,
-                    MMU = new MMU_JR(0,16)
+                    MMU = new MMU_JR(0,16),
+                    RNG = new RNGRegister(MemoryMap.SEEDL_JR, 3)
                 };
             }
 

--- a/Main/MemoryLocations/MemoryManager.cs
+++ b/Main/MemoryLocations/MemoryManager.cs
@@ -42,6 +42,7 @@ namespace FoenixIDE.MemoryLocations
         public TimerRegister TIMER1 = null;
         public TimerRegister TIMER2 = null;
         public RTC RTC = null;
+        public RNGRegister RNG = null;
 
         public bool VectorPull = false;
 
@@ -141,6 +142,15 @@ namespace FoenixIDE.MemoryLocations
                     {
                         Device = MATRIXKEYBOARD.VIA1;
                         DeviceAddress = Address - MATRIXKEYBOARD.VIA1.StartAddress;
+                        return;
+                    }
+                }
+                if (RNG != null)
+                {
+                    if (Address >= RNG.StartAddress && Address <= RNG.EndAddress)
+                    {
+                        Device = RNG;
+                        DeviceAddress = Address - RNG.StartAddress;
                         return;
                     }
                 }
@@ -281,6 +291,15 @@ namespace FoenixIDE.MemoryLocations
                         {
                             Device = MATRIXKEYBOARD.VIA1;
                             DeviceAddress = Address - MATRIXKEYBOARD.VIA1.StartAddress;
+                            return;
+                        }
+                    }
+                    if (RNG != null)
+                    {
+                        if (Address >= RNG.StartAddress && Address <= RNG.EndAddress)
+                        {
+                            Device = RNG;
+                            DeviceAddress = Address - RNG.StartAddress;
                             return;
                         }
                     }

--- a/Main/MemoryLocations/MemoryMap_Gabe.cs
+++ b/Main/MemoryLocations/MemoryMap_Gabe.cs
@@ -38,6 +38,9 @@ namespace FoenixIDE.MemoryLocations
         // F256JR addresses
         public const int SDCARD_JR = 0x00_DD00;
         public const int MATH_JR = 0x00_DE00;
+        public const int SEEDL_JR = 0x00_D6A4;
+        public const int SEEDH_JR = 0x00_D6A5;
+        public const int RND_CTRL_JR = 0x00_D6A6;
 
         // Handling code in CODEC_RAM
         public const int CODEC_START = 0xAF_E820;     // Start of CODEC memory range


### PR DESCRIPTION
This adds support for SEEDL, SEEDH, and RND_CTRL for the F256K and F256 JR board modes. 

It's not intended to replicate an exact simulation or frequency table of values of hw. It's intended to unblock some programs in SuperBASIC that rely on RANDOM(...) and RND(...). That said, it supports the enablement+disablement regs, and re-seeding. Verified gets surfaced through the kernel and BASIC.

Before:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/bcd273cb-50f9-4023-b04d-52b8a330a83c)

After:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/c3639a8a-d554-4efb-bfda-61b07166b389)

