### PR TITLE
Remember user's setting for view size, and allow setting view scale from a preset list

### DIFF
--- a/Main/Display/Gpu.cs
+++ b/Main/Display/Gpu.cs
@@ -36,6 +36,11 @@ namespace FoenixIDE.Display
         private static readonly int[] vs = new int[256 * 8];
         private int[] lutCache = vs;
 
+        public const int NativeHeight = 480;
+        public const int NativeWidth = 768;
+        private int MarginHeight;
+        private int MarginWidth;
+
         public Gpu()
         {
             InitializeComponent();
@@ -65,13 +70,28 @@ namespace FoenixIDE.Display
             {
                 if (ParentForm == null)
                     return;
-                int htarget = 480;
-                int topmargin = ParentForm.Height - ClientRectangle.Height;
-                int sidemargin = ParentForm.Width - ClientRectangle.Width;
-                ParentForm.Height = htarget + topmargin;
-                ParentForm.Width = (int)Math.Ceiling(htarget * 1.6) + sidemargin;
+
+                MarginHeight = ParentForm.Height - ClientRectangle.Height;
+                MarginWidth = ParentForm.Width - ClientRectangle.Width;
+                SetViewSize(NativeWidth, NativeHeight);
+
                 hiresTimer.Start();
             }
+        }
+
+        public void SetViewSize(int viewWidth, int viewHeight)
+        {
+            ParentForm.Height = viewHeight + MarginHeight;
+            ParentForm.Width = viewWidth + MarginWidth;
+        }
+        public int GetViewWidth()
+        {
+            return ParentForm.Width - MarginWidth;
+        }
+
+        public int GetViewHeight()
+        {
+            return ParentForm.Height - MarginHeight;
         }
 
         /// <summary>

--- a/Main/Display/Gpu.cs
+++ b/Main/Display/Gpu.cs
@@ -84,6 +84,16 @@ namespace FoenixIDE.Display
             ParentForm.Height = viewHeight + MarginHeight;
             ParentForm.Width = viewWidth + MarginWidth;
         }
+
+        public void SetViewScaling(float scaling)
+        {
+            int viewHeight = (int)Math.Ceiling((float)NativeHeight * scaling);
+            int viewWidth = (int)Math.Ceiling((float)NativeWidth * scaling);
+
+            ParentForm.Height = viewHeight + MarginHeight;
+            ParentForm.Width = viewWidth + MarginWidth;
+        }
+
         public int GetViewWidth()
         {
             return ParentForm.Width - MarginWidth;

--- a/Main/Properties/Settings.Designer.cs
+++ b/Main/Properties/Settings.Designer.cs
@@ -117,5 +117,35 @@ namespace FoenixIDE.Simulator.Properties {
                 this["SDCardISOMode"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("768")]
+        public int ViewWidth
+        {
+            get
+            {
+                return ((int)(this["ViewWidth"]));
+            }
+            set
+            {
+                this["ViewWidth"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("480")]
+        public int ViewHeight
+        {
+            get
+            {
+                return ((int)(this["ViewHeight"]));
+            }
+            set
+            {
+                this["ViewHeight"] = value;
+            }
+        }
     }
 }

--- a/Main/Properties/Settings.Designer.cs
+++ b/Main/Properties/Settings.Designer.cs
@@ -147,5 +147,20 @@ namespace FoenixIDE.Simulator.Properties {
                 this["ViewHeight"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ViewIsMaximized
+        {
+            get
+            {
+                return ((bool)(this["ViewIsMaximized"]));
+            }
+            set
+            {
+                this["ViewIsMaximized"] = value;
+            }
+        }
     }
 }

--- a/Main/UI/MainWindow.Designer.cs
+++ b/Main/UI/MainWindow.Designer.cs
@@ -62,6 +62,10 @@ namespace FoenixIDE.UI
             this.mIDIToVGMConvertToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.autorunEmulatorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.viewScalingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale1_0XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale1_5XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale2_0XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.windowsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.terminalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cPUToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -348,7 +352,8 @@ namespace FoenixIDE.UI
             // settingsToolStripMenuItem
             // 
             this.settingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.autorunEmulatorToolStripMenuItem});
+            this.autorunEmulatorToolStripMenuItem,
+            this.viewScalingToolStripMenuItem});
             this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
             this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
             this.settingsToolStripMenuItem.Text = "&Settings";
@@ -367,6 +372,40 @@ namespace FoenixIDE.UI
             this.autorunEmulatorToolStripMenuItem.Size = new System.Drawing.Size(169, 23);
             this.autorunEmulatorToolStripMenuItem.Text = "Autorun Emulator";
             this.autorunEmulatorToolStripMenuItem.Click += new System.EventHandler(this.AutorunEmulatorToolStripMenuItem_Click);
+            // 
+            // viewScalingToolStripMenuItem
+            // 
+            this.viewScalingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.scale1_0XToolStripMenuItem,
+            this.scale1_5XToolStripMenuItem,
+            this.scale2_0XToolStripMenuItem});
+            this.viewScalingToolStripMenuItem.Name = "viewScalingToolStripMenuItem";
+            this.viewScalingToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
+            this.viewScalingToolStripMenuItem.Text = "View Scaling";
+            // 
+            // scale1_0XToolStripMenuItem
+            // 
+            this.scale1_0XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_0XToolStripMenuItem.Name = "scale1_0XToolStripMenuItem";
+            this.scale1_0XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_0XToolStripMenuItem.Text = "Scale 1.0X";
+            this.scale1_0XToolStripMenuItem.Click += new System.EventHandler(this.scale1_0XToolStripMenuItem_Click);
+            // 
+            // scale1_5XToolStripMenuItem
+            // 
+            this.scale1_5XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_5XToolStripMenuItem.Name = "scale1_5XToolStripMenuItem";
+            this.scale1_5XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_5XToolStripMenuItem.Text = "Scale 1.5X";
+            this.scale1_5XToolStripMenuItem.Click += new System.EventHandler(this.scale1_5XToolStripMenuItem_Click);
+            // 
+            // scale2_0XToolStripMenuItem
+            // 
+            this.scale2_0XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale2_0XToolStripMenuItem.Name = "scale2_0XToolStripMenuItem";
+            this.scale2_0XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale2_0XToolStripMenuItem.Text = "Scale 2.0X";
+            this.scale2_0XToolStripMenuItem.Click += new System.EventHandler(this.scale2_0XToolStripMenuItem_Click);
             // 
             // windowsToolStripMenuItem
             // 
@@ -578,6 +617,10 @@ namespace FoenixIDE.UI
         private System.Windows.Forms.ToolStripMenuItem DefaultKernelToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem convertHexToPGZToolStripMenuItem;
         public Gpu gpu;
+        private System.Windows.Forms.ToolStripMenuItem viewScalingToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_0XToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale2_0XToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_5XToolStripMenuItem;
     }
 }
 

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -307,7 +307,14 @@ namespace FoenixIDE.UI
             }
             autorunEmulatorToolStripMenuItem.Checked = autoRun;
 
-            gpu.SetViewSize(Simulator.Properties.Settings.Default.ViewWidth, Simulator.Properties.Settings.Default.ViewHeight);
+            if (Simulator.Properties.Settings.Default.ViewIsMaximized)
+            {
+                this.WindowState = FormWindowState.Maximized;
+            }
+            else
+            {
+                gpu.SetViewSize(Simulator.Properties.Settings.Default.ViewWidth, Simulator.Properties.Settings.Default.ViewHeight);
+            }
         }
 
         private void CenterForm(Form form)
@@ -913,6 +920,7 @@ namespace FoenixIDE.UI
 
             Simulator.Properties.Settings.Default.ViewWidth = gpu.GetViewWidth();
             Simulator.Properties.Settings.Default.ViewHeight = gpu.GetViewHeight();
+            Simulator.Properties.Settings.Default.ViewIsMaximized = this.WindowState == FormWindowState.Maximized;
             Simulator.Properties.Settings.Default.Save();
 
             if (debugWindow != null)
@@ -1853,16 +1861,19 @@ namespace FoenixIDE.UI
 
         private void scale1_0XToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            this.WindowState = FormWindowState.Normal;
             gpu.SetViewScaling(1.0f);
         }
 
         private void scale1_5XToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            this.WindowState = FormWindowState.Normal;
             gpu.SetViewScaling(1.5f);
         }
 
         private void scale2_0XToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            this.WindowState = FormWindowState.Normal;
             gpu.SetViewScaling(2.0f);
         }
     }

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -1850,6 +1850,21 @@ namespace FoenixIDE.UI
             MIDI_VGM_From midiForm = new MIDI_VGM_From();
             midiForm.Show();
         }
+
+        private void scale1_0XToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            gpu.SetViewScaling(1.0f);
+        }
+
+        private void scale1_5XToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            gpu.SetViewScaling(1.5f);
+        }
+
+        private void scale2_0XToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            gpu.SetViewScaling(2.0f);
+        }
     }
 }
 

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -306,6 +306,8 @@ namespace FoenixIDE.UI
                 debugWindow.RunButton_Click(null, null);
             }
             autorunEmulatorToolStripMenuItem.Checked = autoRun;
+
+            gpu.SetViewSize(Simulator.Properties.Settings.Default.ViewWidth, Simulator.Properties.Settings.Default.ViewHeight);
         }
 
         private void CenterForm(Form form)
@@ -908,6 +910,10 @@ namespace FoenixIDE.UI
                     kernel.CPU.CPUThread.Join(1000);
                 }
             }
+
+            Simulator.Properties.Settings.Default.ViewWidth = gpu.GetViewWidth();
+            Simulator.Properties.Settings.Default.ViewHeight = gpu.GetViewHeight();
+            Simulator.Properties.Settings.Default.Save();
 
             if (debugWindow != null)
             {


### PR DESCRIPTION
This change does two things:
* Remembers your settings for what the view size is
* Lets you set view scale from a preset list

Reason for remembering setting: text can be hard to read at native size, particularly on high DPI displays. For users that are repeatedly booting into BASIC and reading text, it's convenient not to have to resize the window every time.

Reason for set view scale: some applications look best with uniform scaling. But it's hard for users to resize carefully manually to achieve that. This adds some options to automatically do it. And there's also an option to get back to 1x scaling if you accidentally resized the window.

The preset scaling options are
* 1.0x
* 1.5x
* 2.0x

The UI to select them looks like
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/a49b9bf5-dff3-46af-bb2a-12347b722e17)
