### PR TITLE
Allow right-clicking on the debug window to copy to clipboard

### DIFF
--- a/Main/UI/CPUWindow.Designer.cs
+++ b/Main/UI/CPUWindow.Designer.cs
@@ -54,6 +54,8 @@ namespace FoenixIDE.UI
             this.StepOverOverlayButton = new System.Windows.Forms.Button();
             this.HeaderTextbox = new System.Windows.Forms.Label();
             this.irqPanel = new System.Windows.Forms.Panel();
+            this.debugWindowContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.debugWindowCopyToClipboardMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.GabeInt1Check = new FoenixIDE.Simulator.Controls.ColorCheckBox();
             this.VDMACheck = new FoenixIDE.Simulator.Controls.ColorCheckBox();
             this.V2TileColCheck = new FoenixIDE.Simulator.Controls.ColorCheckBox();
@@ -89,6 +91,7 @@ namespace FoenixIDE.UI
             this.SecondPanel.SuspendLayout();
             this.irqPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DebugPanel)).BeginInit();
+            this.debugWindowContextMenuStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // HeaderPanel
@@ -389,6 +392,21 @@ namespace FoenixIDE.UI
             this.irqPanel.Name = "irqPanel";
             this.irqPanel.Size = new System.Drawing.Size(226, 74);
             this.irqPanel.TabIndex = 12;
+            // 
+            // 
+            // debugWindowContextMenuStrip
+            // 
+            this.debugWindowContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.debugWindowCopyToClipboardMenuItem});
+            this.debugWindowContextMenuStrip.Name = "debugWindowContextMenuStrip";
+            this.debugWindowContextMenuStrip.Size = new System.Drawing.Size(181, 48);
+            this.debugWindowCopyToClipboardMenuItem.Click += DebugWindowCopyToClipboardMenuItem_Click;
+            // 
+            // debugWindowCopyToClipboardMenuItem
+            // 
+            this.debugWindowCopyToClipboardMenuItem.Name = "debugWindowCopyToClipboardMenuItem";
+            this.debugWindowCopyToClipboardMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.debugWindowCopyToClipboardMenuItem.Text = "Copy to Clipboard";
             // 
             // GabeInt1Check
             // 
@@ -878,6 +896,7 @@ namespace FoenixIDE.UI
             this.irqPanel.ResumeLayout(false);
             this.irqPanel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DebugPanel)).EndInit();
+            this.debugWindowContextMenuStrip.ResumeLayout(false);
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -938,5 +957,7 @@ namespace FoenixIDE.UI
         private ColorCheckBox ExtExpCheck;
         private ColorCheckBox SDCardInsertCheck;
         private ColorCheckBox ParallelPortCheck;
+        private System.Windows.Forms.ContextMenuStrip debugWindowContextMenuStrip;
+        private System.Windows.Forms.ToolStripMenuItem debugWindowCopyToClipboardMenuItem;
     }
 }

--- a/Main/UI/CPUWindow.resx
+++ b/Main/UI/CPUWindow.resx
@@ -273,6 +273,9 @@
   <metadata name="DebugPanel.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="debugWindowContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>349, 17</value>
+  </metadata>
   <metadata name="registerDisplay1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>


### PR DESCRIPTION
This change allows the user to right click on the debug window, to bring up a context menu:
![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/9a32175c-a3f5-447b-bce8-eed997a1f663)

Clicking "Copy to clipboard" will copy the displayed code list to the clipboard. This can be useful for debugging workflows, for example, to saving some code in notes where you don't have an LST file.