### PR TITLE
Block attempt to write read-only memory on F256

### DIFF
--- a/Main/FileFormat/HexFile.cs
+++ b/Main/FileFormat/HexFile.cs
@@ -8,7 +8,7 @@ namespace FoenixIDE.Simulator.FileFormat
     public class HexFile
     {
 
-        static public bool Load(MemoryRAM ram, string Filename, int gabeAddressBank, out List<int> blocks, out List<int> blockLengths)
+        static public bool Load(MemoryRAM ram, FlashJr romJr, string Filename, int gabeAddressBank, out List<int> blocks, out List<int> blockLengths)
         {
             int bank = 0;
             int addrCursor = 0;
@@ -65,7 +65,16 @@ namespace FoenixIDE.Simulator.FileFormat
                                 for (int i = 0; i < data.Length; i += 2)
                                 {
                                     int b = GetByte(data, i, 1);
-                                    ram.WriteByte(bank + addrCursor, (byte)b);
+
+                                    if (romJr != null && bank >= 0x08_0000 && bank <= 0x10_0000)
+                                    {
+                                        romJr.SetFlash(bank + addrCursor - 0x08_0000, (byte)b);
+                                    }
+                                    else
+                                    {
+                                        ram.WriteByte(bank + addrCursor, (byte)b);
+                                    }
+
                                     // Copy bank $38 or $18 to page 0
                                     if (bank == gabeAddressBank)
                                     {

--- a/Main/FoenixIDE.csproj
+++ b/Main/FoenixIDE.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Devices\CodecRAM.cs" />
     <Compile Include="FileFormat\ListFile.cs" />
     <Compile Include="FileFormat\WatchedMemory.cs" />
+    <Compile Include="MemoryLocations\FlashJr.cs" />
     <Compile Include="MemoryLocations\IMappable.cs" />
     <Compile Include="Devices\MathCoproRegister.cs" />
     <Compile Include="Devices\SDCard\SDCardDevice.cs" />

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -496,7 +496,17 @@ namespace FoenixIDE
                 } while (!isAddressValid);
                 // Copy the data into memory
                 MemMgr.RAM.CopyBuffer(DataBuffer, 0, DataStartAddress, flen);
-                //MemMgr.CopyBuffer(DataBuffer, 0, DataStartAddress, flen);
+
+                if (BoardVersionHelpers.IsJr(boardVersion))
+                {
+                    bool binOverlapsFlash = DataStartAddress >= 0x08_0000;
+                    if (binOverlapsFlash)
+                    {
+                        int flashStart = DataStartAddress - 0x08_0000;
+                        int flashEnd = Math.Min(flashStart + flen, 0x10_0000);
+                        MemMgr.FLASHJR.CopyBuffer(DataBuffer, 0, flashStart, flashEnd - flashStart);
+                    }
+                }
             }
 
             // Load the .LST file if it exists

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -50,7 +50,7 @@ namespace FoenixIDE
                     keyboardAddress = MemoryMap.KBD_DATA_BUF_U;
                     break;
                 case BoardVersion.RevJr_6502:
-                    memSize = 1024*1024;
+                    memSize = 1024*1024; // Includes both RAM and flash.
                     keyboardAddress = MemoryMap.KBD_DATA_BUF_JR;
                     clock = 6293000;
                     is6502 = true;
@@ -118,6 +118,7 @@ namespace FoenixIDE
                 MemMgr = new MemoryManager
                 {
                     RAM = new MemoryRAM(MemoryMap.RAM_START, memSize),
+                    FLASHJR = new FlashJr(MemoryMap.RAM_START, 0x08_0000),
                     // vicky will store 4 pages of data
                     VICKY = new MemoryRAM(0, 4 * 0x2000),
                     PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
@@ -380,7 +381,7 @@ namespace FoenixIDE
             }
             if (extension.Equals(".HEX"))
             {
-                if (!HexFile.Load(MemMgr.RAM, LoadedKernel, BasePageAddress, out _, out _))
+                if (!HexFile.Load(MemMgr.RAM, MemMgr.FLASHJR, LoadedKernel, BasePageAddress, out _, out _))
                 {
                     return false;
                 }

--- a/Main/MemoryLocations/FlashJr.cs
+++ b/Main/MemoryLocations/FlashJr.cs
@@ -1,0 +1,19 @@
+﻿namespace FoenixIDE.MemoryLocations
+{
+    public class FlashJr : FoenixIDE.MemoryLocations.MemoryRAM
+    {
+        public FlashJr(int StartAddress, int Length) : base(StartAddress, Length)
+        {
+        }
+
+        public void SetFlash(int Address, byte Value)
+        {
+            data[Address] = Value;
+        }
+
+        public override void WriteByte(int Address, byte Value)
+        {
+            // CPU write of flash memory is not allowed.
+        }
+    }
+}

--- a/Main/MemoryLocations/MemoryRAM.cs
+++ b/Main/MemoryLocations/MemoryRAM.cs
@@ -43,10 +43,6 @@ namespace FoenixIDE.MemoryLocations
             data = new byte[Length];
         }
 
-        private MemoryRAM()
-        {
-        }
-
         /// <summary>
         /// Clear all the bytes in the memory array.
         /// </summary>

--- a/Main/UI/AssetLoader.cs
+++ b/Main/UI/AssetLoader.cs
@@ -248,7 +248,7 @@ namespace FoenixIDE.UI
                 case ".hex":
                     MemoryRAM memory = new MemoryRAM(0, FoenixSystem.TextAddressToInt(FileSizeResultLabel.Text) );
                     List<int> blockSizes;
-                    if (HexFile.Load(memory, FileNameTextBox.Text, 0, out _, out blockSizes))
+                    if (HexFile.Load(memory, null, FileNameTextBox.Text, 0, out _, out blockSizes))
                     {
 
                         res.Length = blockSizes[0];

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -1621,7 +1621,7 @@ namespace FoenixIDE.UI
             if (dialog.ShowDialog() == DialogResult.OK)
             {
                 MemoryRAM temporaryRAM = new MemoryRAM(0, 4 * 1024 * 1024);
-                HexFile.Load(temporaryRAM, dialog.FileName, 0, out List<int> DataStartAddress, out List<int> DataLength);
+                HexFile.Load(temporaryRAM, null, dialog.FileName, 0, out List<int> DataStartAddress, out List<int> DataLength);
 
                 if (DataStartAddress.Count > 1)
                 {
@@ -1660,7 +1660,7 @@ namespace FoenixIDE.UI
             if (dialog.ShowDialog() == DialogResult.OK)
             {
                 MemoryRAM temporaryRAM = new MemoryRAM(0, 4 * 1024 * 1024);
-                HexFile.Load(temporaryRAM, dialog.FileName, 0, out List<int> DataStartAddress, out List<int> DataLength);
+                HexFile.Load(temporaryRAM, null, dialog.FileName, 0, out List<int> DataStartAddress, out List<int> DataLength);
                 // write the file
                 string outputFileName = Path.ChangeExtension(dialog.FileName, "PGZ");
 


### PR DESCRIPTION
Before this fix: if you have a program that accidentally attempts to CPU write flash memory, you'll see different behavior between emulator and hardware. Hardware will block the write, emulator allows it.

This fixes it so that emulator also blocks the write.

The fix works by designating a separate MemoryMap called "FLASHJR". It's initialized through loading the kernel, and then CPU writes afterward are blocked.