### PR TITLE
Unblock F256K keyboard emulation on latest kernel

### DIFF
--- a/Main/Devices/BoardVersion.cs
+++ b/Main/Devices/BoardVersion.cs
@@ -13,14 +13,19 @@ namespace FoenixIDE.Simulator.Devices
         RevU,
         RevUPlus,
         RevJr_6502,
-        RevJr_65816
+        RevJr_65816,
+        RevF256K_6502,
+        RevF256K_65816
     }
     
     public static class BoardVersionHelpers
     {
         public static bool IsF256(BoardVersion boardVersion)
         {
-            return boardVersion == BoardVersion.RevJr_6502 || boardVersion == BoardVersion.RevJr_65816;
+            return boardVersion == BoardVersion.RevJr_6502 || 
+                   boardVersion == BoardVersion.RevJr_65816 ||
+                   boardVersion == BoardVersion.RevF256K_6502 ||
+                   boardVersion == BoardVersion.RevF256K_65816;
         }
     }
 }

--- a/Main/Devices/BoardVersion.cs
+++ b/Main/Devices/BoardVersion.cs
@@ -18,7 +18,7 @@ namespace FoenixIDE.Simulator.Devices
     
     public static class BoardVersionHelpers
     {
-        public static bool IsJr(BoardVersion boardVersion)
+        public static bool IsF256(BoardVersion boardVersion)
         {
             return boardVersion == BoardVersion.RevJr_6502 || boardVersion == BoardVersion.RevJr_65816;
         }

--- a/Main/Devices/PS2KeyboardRegister.cs
+++ b/Main/Devices/PS2KeyboardRegister.cs
@@ -10,12 +10,20 @@ namespace FoenixIDE.Simulator.Devices
         private byte ps2PacketCntr = 0;
         private int packetLength = 0;
         private byte[] ps2packet = new byte[6];
+        private Mode mode; // Mode 1 for C256, Mode 2 for F256
         public delegate void TriggerInterruptDelegate();
         public TriggerInterruptDelegate TriggerKeyboardInterrupt;
         public TriggerInterruptDelegate TriggerMouseInterrupt;
 
-        public PS2KeyboardRegister(int StartAddress, int Length) : base(StartAddress, Length)
+        public enum Mode
         {
+            Mode1,
+            Mode2
+        }
+
+        public PS2KeyboardRegister(int StartAddress, int Length, Mode m) : base(StartAddress, Length)
+        {
+            mode = m;
         }
 
         // This is used to simulate the Keyboard Register
@@ -143,6 +151,11 @@ namespace FoenixIDE.Simulator.Devices
                     }
                 }
                 return data[0];
+            }
+            else if (Address == 4 && mode == Mode.Mode2)
+            {
+                // PS2 mode 2 keyboards are not currently supported, so always return 0b11, indicating that they keyboard and mouse queues are empty.
+                return 3;
             }
             else if (Address == 5)
             {

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -93,7 +93,7 @@ namespace FoenixIDE
 
                     // Special devices
                     MATH = new MathCoproRegister(MemoryMap.MATH_START, MemoryMap.MATH_END - MemoryMap.MATH_START + 1), // 48 bytes
-                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
+                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5, PS2KeyboardRegister.Mode.Mode1),
                     SDCARD = sdcard,
                     INTERRUPT = new InterruptController(MemoryMap.INT_PENDING_REG0, 4),
                     UART1 = new UART(MemoryMap.UART1_REGISTERS, 8),
@@ -116,14 +116,14 @@ namespace FoenixIDE
             }
             else
             {
-                // This is either a 6502-based machine, or a 65816-based F256* with the same memory map
+                // This is a 6502 or 85816-based F256 machine; both have the same memory map
                 MemMgr = new MemoryManager
                 {
                     RAM = new MemoryRAM(MemoryMap.RAM_START, memSize),
                     FLASHJR = new FlashJr(MemoryMap.RAM_START, 0x08_0000),
                     // vicky will store 4 pages of data
                     VICKY = new MemoryRAM(0, 4 * 0x2000),
-                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5),
+                    PS2KEYBOARD = new PS2KeyboardRegister(keyboardAddress, 5, PS2KeyboardRegister.Mode.Mode2),
                     MATRIXKEYBOARD = new MatrixKeyboardRegister(MemoryMap.MATRIX_KEYBOARD_VIA0_PORT_B, 4, MemoryMap.MATRIX_KEYBOARD_VIA1_PORT_B, 4),
                     MATH = new MathCoproRegister(MemoryMap.MATH_START_JR, MemoryMap.MATH_END_JR - MemoryMap.MATH_START_JR + 1), // 32 bytes
                     SDCARD = sdcard,

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -185,7 +185,15 @@ namespace FoenixIDE
             }
             else
             {
-                MemMgr.WriteByte(MemoryMap.REVOFJR, 0x2);
+                if (boardVersion == BoardVersion.RevJr_6502 || boardVersion == BoardVersion.RevJr_65816)
+                {
+                    MemMgr.WriteByte(MemoryMap.REVOFJR, 0x2);
+                }
+                else
+                {
+                    System.Diagnostics.Debug.Assert(boardVersion == BoardVersion.RevF256K_6502 || boardVersion == BoardVersion.RevF256K_65816);
+                    MemMgr.WriteByte(MemoryMap.REVOFJR, 0x12);
+                }
                 MemMgr.VICKY.WriteWord(0xD000 - 0xC000, 1);
                 MemMgr.VICKY.WriteWord(0xD002 - 0xC000, 0x1540);
                 string applicationDirectory = System.AppContext.BaseDirectory;

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -67,7 +67,7 @@ namespace FoenixIDE
                 codec = new CodecRAM(MemoryMap.CODEC_WR_CTRL, 4);
                 sdcard = new CH376SRegister(MemoryMap.SDCARD_DATA, MemoryMap.SDCARD_SIZE);
             }
-            else if (BoardVersionHelpers.IsJr(boardVersion))
+            else if (BoardVersionHelpers.IsF256(boardVersion))
             {
                 codec = new CodecRAM(MemoryMap.CODEC_WR_CTRL_JR, 3);  // unlike the FMX, this register is 16-bits in F256Jr
                 sdcard = new F256SDController(MemoryMap.SDCARD_JR, 2);
@@ -78,7 +78,7 @@ namespace FoenixIDE
                 sdcard = new GabeSDController(MemoryMap.GABE_SDC_CTRL_START, MemoryMap.GABE_SDC_CTRL_SIZE);
             }
 
-            if (!BoardVersionHelpers.IsJr(boardVersion))
+            if (!BoardVersionHelpers.IsF256(boardVersion))
             {
                 // These are the strictly 65816-based machines
                 MemMgr = new MemoryManager
@@ -114,7 +114,7 @@ namespace FoenixIDE
             }
             else
             {
-                // This is either a 6502-based machine, or a 65816-based Jr with the same memory map
+                // This is either a 6502-based machine, or a 65816-based F256* with the same memory map
                 MemMgr = new MemoryManager
                 {
                     RAM = new MemoryRAM(MemoryMap.RAM_START, memSize),
@@ -142,7 +142,7 @@ namespace FoenixIDE
             // Load the kernel.hex if present
             ResetCPU(DefaultKernel);
 
-            if (!BoardVersionHelpers.IsJr(boardVersion))
+            if (!BoardVersionHelpers.IsF256(boardVersion))
             {
                 // Write bytes $9F in the joystick registers to mean that they are not installed.
                 MemMgr.WriteWord(0xAFE800, 0x9F9F);
@@ -211,7 +211,7 @@ namespace FoenixIDE
 
         private void TimerEvent0()
         {
-            if (!BoardVersionHelpers.IsJr(boardVersion))
+            if (!BoardVersionHelpers.IsF256(boardVersion))
             {
                 byte mask =  MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
                 if (!CPU.DebugPause && !CPU.Flags.IrqDisable && ((~mask & (byte)Register0.FNX0_INT02_TMR0) == (byte)Register0.FNX0_INT02_TMR0))
@@ -238,7 +238,7 @@ namespace FoenixIDE
         }
         private void TimerEvent1()
         {
-            if (!BoardVersionHelpers.IsJr(boardVersion))
+            if (!BoardVersionHelpers.IsF256(boardVersion))
             {
                 byte mask = MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
                 if (!CPU.DebugPause && !CPU.Flags.IrqDisable && ((~mask & (byte)Register0.FNX0_INT03_TMR1) == (byte)Register0.FNX0_INT03_TMR1))
@@ -280,7 +280,7 @@ namespace FoenixIDE
 
         private void RTCAlarmEvents()
         {
-            if (!BoardVersionHelpers.IsJr(boardVersion))
+            if (!BoardVersionHelpers.IsF256(boardVersion))
             {
                 byte mask = MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
                 if (!CPU.DebugPause && !CPU.Flags.IrqDisable && ((~mask & (byte)Register0.FNX0_INT05_RTC) == (byte)Register0.FNX0_INT05_RTC))
@@ -357,7 +357,7 @@ namespace FoenixIDE
             string extension = info.Extension.ToUpper();
             if (info.Name.StartsWith("kernel"))
             {
-                if (BoardVersionHelpers.IsJr(boardVersion))
+                if (BoardVersionHelpers.IsF256(boardVersion))
                 {
                     MemMgr.MMU.Reset();
                 }
@@ -365,7 +365,7 @@ namespace FoenixIDE
             else
             { 
                 // Ensure the first LUTs are set correctly - but don't overwrite the kernel.
-                if (BoardVersionHelpers.IsJr(boardVersion))
+                if (BoardVersionHelpers.IsF256(boardVersion))
                 {
                     MemMgr.MMU.SetActiveLUT(0);
                     MemMgr.MMU.WriteByte(0x8, 0);
@@ -447,7 +447,7 @@ namespace FoenixIDE
                 } while (reader.BaseStream.Position < info.Length);
                 reader.Close();
 
-                if (!BoardVersionHelpers.IsJr(boardVersion))
+                if (!BoardVersionHelpers.IsF256(boardVersion))
                 {
                     // This is pretty messed up... ERESET points to $FF00, which has simple load routine.
                     MemMgr.WriteWord(MemoryMap.VECTOR_ERESET, 0xFF00);
@@ -497,7 +497,7 @@ namespace FoenixIDE
                 // Copy the data into memory
                 MemMgr.RAM.CopyBuffer(DataBuffer, 0, DataStartAddress, flen);
 
-                if (BoardVersionHelpers.IsJr(boardVersion))
+                if (BoardVersionHelpers.IsF256(boardVersion))
                 {
                     bool binOverlapsFlash = DataStartAddress >= 0x08_0000;
                     if (binOverlapsFlash)

--- a/Main/FoenixSystem.cs
+++ b/Main/FoenixSystem.cs
@@ -50,12 +50,14 @@ namespace FoenixIDE
                     keyboardAddress = MemoryMap.KBD_DATA_BUF_U;
                     break;
                 case BoardVersion.RevJr_6502:
+                case BoardVersion.RevF256K_6502:
                     memSize = 1024*1024; // Includes both RAM and flash.
                     keyboardAddress = MemoryMap.KBD_DATA_BUF_JR;
                     clock = 6293000;
                     is6502 = true;
                     break;
                 case BoardVersion.RevJr_65816:
+                case BoardVersion.RevF256K_65816:
                     memSize = 1024 * 1024;
                     keyboardAddress = MemoryMap.KBD_DATA_BUF_JR;
                     clock = 6293000;

--- a/Main/Program.cs
+++ b/Main/Program.cs
@@ -128,8 +128,14 @@ namespace FoenixIDE
                                 case "jr816":
                                     context.Add("version", "RevJr816");
                                     break;
+                                case "f256k":
+                                    context.Add("version", "RevF256K");
+                                    break;
+                                case "f256k816":
+                                    context.Add("version", "RevF256K816");
+                                    break;
                                 default:
-                                    Console.Out.WriteLine("Invalid board specified: " + verArg + ". Must be one of b, c, u, u+, jr, jr816");
+                                    Console.Out.WriteLine("Invalid board specified: " + verArg + ". Must be one of b, c, u, u+, jr, jr816, f256k, f256k816");
                                     context["Continue"] = "false";
                                     break;
                             }

--- a/Main/UI/CPUWindow.cs
+++ b/Main/UI/CPUWindow.cs
@@ -241,8 +241,8 @@ namespace FoenixIDE.UI
 
         private void DisplayInterruptTooltips()
         {
-            bool isJunior = BoardVersionHelpers.IsJr(boardVersion);
-            if (isJunior)
+            bool isF256 = BoardVersionHelpers.IsF256(boardVersion);
+            if (isF256)
             {
                 // this is going to be confusing - the F256 Interrupts are different
                 // Register 0
@@ -462,7 +462,7 @@ namespace FoenixIDE.UI
                 IRQPC = -1;
                 kernel.MemMgr.INTERRUPT.WriteFromGabe(0, 0);
                 kernel.MemMgr.INTERRUPT.WriteFromGabe(1, 0);
-                if (!BoardVersionHelpers.IsJr(kernel.GetVersion()))
+                if (!BoardVersionHelpers.IsF256(kernel.GetVersion()))
                 {
                     kernel.MemMgr.INTERRUPT.WriteFromGabe(2, 0);
                     kernel.MemMgr.INTERRUPT.WriteFromGabe(3, 0);
@@ -896,7 +896,7 @@ namespace FoenixIDE.UI
         private void BreakOnIRQCheckBox_CheckedChanged(object sender, EventArgs e)
         {
             bool visible = BreakOnIRQCheckBox.Checked;
-            if (BoardVersionHelpers.IsJr(boardVersion))
+            if (BoardVersionHelpers.IsF256(boardVersion))
             {
                 // Row 1
                 SOFCheckbox.Visible = visible;
@@ -1002,7 +1002,7 @@ namespace FoenixIDE.UI
             }
 
             // The F256s do not have the following registers
-            if (!BoardVersionHelpers.IsJr(kernel.GetVersion()))
+            if (!BoardVersionHelpers.IsF256(kernel.GetVersion()))
             {
                 //Read Interrupt Register 2 - we don't handle these yet
                 byte reg2 = kernel.MemMgr.INTERRUPT.ReadByte(2);

--- a/Main/UI/MainWindow.Designer.cs
+++ b/Main/UI/MainWindow.Designer.cs
@@ -85,6 +85,8 @@ namespace FoenixIDE.UI
             this.revUPlusToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.revJrToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.revJr816ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.revF256KToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.revF256K816ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.revBToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.gpu = new FoenixIDE.Display.Gpu();
             this.statusStrip1.SuspendLayout();
@@ -119,7 +121,9 @@ namespace FoenixIDE.UI
             this.revUToolStripMenuItem,
             this.revUPlusToolStripMenuItem,
             this.revJrToolStripMenuItem,
-            this.revJr816ToolStripMenuItem});
+            this.revJr816ToolStripMenuItem,
+            this.revF256KToolStripMenuItem,
+            this.revF256K816ToolStripMenuItem});
             this.toolStripRevision.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
             this.toolStripRevision.Name = "toolStripRevision";
             this.toolStripRevision.Size = new System.Drawing.Size(110, 28);
@@ -554,6 +558,18 @@ namespace FoenixIDE.UI
             this.revJr816ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.revJr816ToolStripMenuItem.Text = "Rev Jr(816)";
             // 
+            // revF256KToolStripMenuItem
+            // 
+            this.revF256KToolStripMenuItem.Name = "revF256KToolStripMenuItem";
+            this.revF256KToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.revF256KToolStripMenuItem.Text = "Rev F256K";
+            // 
+            // revF256K816ToolStripMenuItem
+            // 
+            this.revF256K816ToolStripMenuItem.Name = "revF256K816ToolStripMenuItem";
+            this.revF256K816ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.revF256K816ToolStripMenuItem.Text = "Rev F256K(816)";
+            // 
             // revBToolStripMenuItem
             // 
             this.revBToolStripMenuItem.Name = "revBToolStripMenuItem";
@@ -665,7 +681,9 @@ namespace FoenixIDE.UI
         private System.Windows.Forms.ToolStripMenuItem viewScalingToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem scale1_0XToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem scale2_0XToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem scale1_5XToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_5XToolStripMenuItem;        
+        private System.Windows.Forms.ToolStripMenuItem revF256K816ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem revF256KToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revJr816ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revJrToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revUPlusToolStripMenuItem;

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -197,7 +197,7 @@ namespace FoenixIDE.UI
                 gpu.GpuUpdated += Gpu_Update_Cps_Fps;
             }
             gpu.VICKY = kernel.MemMgr.VICKY;
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 gpu.SetMode(0);
                 gpu.VRAM = kernel.MemMgr.VIDEO;
@@ -278,7 +278,7 @@ namespace FoenixIDE.UI
             }
 
             SetDipSwitchMemory();
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 // Code is tightly coupled with memory manager
                 kernel.MemMgr.UART1.TransmitByte += SerialTransmitByte;
@@ -471,7 +471,7 @@ namespace FoenixIDE.UI
         {
             // Check if the interrupt is enabled
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 // we need to this to avoid using the MMU IO Paging function
                 mask = kernel.MemMgr.VICKY.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR - 0xC000);
@@ -481,7 +481,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SOF Interrupt
                 byte IRQ0 = kernel.MemMgr.INTERRUPT.ReadByte(0);
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     // we need to this to avoid using the MMU IO Paging function
                     IRQ0 = kernel.MemMgr.VICKY.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR - 0xC000);
@@ -499,7 +499,7 @@ namespace FoenixIDE.UI
         {
             // Check if the interrupt is enabled
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0);
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR);
             }
@@ -508,7 +508,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SOL Interrupt
                 byte IRQ0 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0);
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     IRQ0 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR - 0xC000);
                 }
@@ -527,7 +527,7 @@ namespace FoenixIDE.UI
         {
             // Check if the SD Card interrupt is allowed
             byte mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG1);
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 mask = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_MASK_REG0_JR + 1);
             }
@@ -535,7 +535,7 @@ namespace FoenixIDE.UI
             {
                 // Set the SD Card Interrupt
                 byte IRQ1 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG1);
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     IRQ1 = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.INT_PENDING_REG0_JR + 1);
                 }
@@ -628,7 +628,7 @@ namespace FoenixIDE.UI
 
         private void WriteKeyboardCode(ScanCode sc)
         {
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 // Check if the Keyboard interrupt is allowed
                 byte mask = kernel.MemMgr.ReadByte(MemoryMap.INT_MASK_REG1);
@@ -661,7 +661,7 @@ namespace FoenixIDE.UI
         }
         private void TriggerKeyboardInterrupt()
         {
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 // Set the Keyboard Interrupt
                 byte IrqVal = kernel.MemMgr.INTERRUPT.ReadByte(1);
@@ -681,7 +681,7 @@ namespace FoenixIDE.UI
 
         private void TriggerMouseInterrupt()
         {
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 // Set the Mouse Interrupt
                 byte IRQ0 = kernel.MemMgr.INTERRUPT.ReadByte(0);
@@ -810,7 +810,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     // Now update other registers
                     //kernel.MemMgr.MMU.Reset();
@@ -838,7 +838,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     // Now update other registers
                     kernel.MemMgr.MMU.Reset();
@@ -863,7 +863,7 @@ namespace FoenixIDE.UI
                 debugWindow.ClearTrace();
                 SetDipSwitchMemory();
                 memoryWindow.Memory = kernel.CPU.MemMgr;
-                if (BoardVersionHelpers.IsJr(version))
+                if (BoardVersionHelpers.IsF256(version))
                 {
                     // Now update other registers
                     kernel.MemMgr.MMU.Reset();
@@ -968,7 +968,7 @@ namespace FoenixIDE.UI
                     debugWindow.Pause();
                     SetDipSwitchMemory();
                     ShowDebugWindow(version);
-                    if (BoardVersionHelpers.IsJr(version))
+                    if (BoardVersionHelpers.IsF256(version))
                     {
                         // Now update other registers
                         kernel.MemMgr.MMU.Reset();
@@ -1050,7 +1050,7 @@ namespace FoenixIDE.UI
         {
             gpu.TileEditorMode = false;
             // Restore the previous graphics mode
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 kernel.MemMgr.VICKY.WriteByte(0, previousGraphicMode);
             }
@@ -1072,7 +1072,7 @@ namespace FoenixIDE.UI
                 tileEditor.SetResourceChecker(kernel.ResCheckerRef);
                 gpu.TileEditorMode = true;
                 // Set Vicky into Tile mode
-                if (!BoardVersionHelpers.IsJr(version))
+                if (!BoardVersionHelpers.IsF256(version))
                 {
                     previousGraphicMode = kernel.MemMgr.VICKY.ReadByte(0);
                     kernel.MemMgr.VICKY.WriteByte(0, 0x10);
@@ -1112,13 +1112,13 @@ namespace FoenixIDE.UI
         private void Gpu_MouseMove(object sender, MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 size = gpu.GetScreenSize_JR();
             }
             float ratioW = gpu.Width / (float)size.X;
             float ratioH = gpu.Height / (float)size.Y;
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 bool borderEnabled = kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.BORDER_CTRL_REG) == 1;
                 double borderWidth = borderEnabled ? kernel.MemMgr.ReadByte(MemoryLocations.MemoryMap.BORDER_X_SIZE) : 0;
@@ -1146,7 +1146,7 @@ namespace FoenixIDE.UI
         private void Gpu_MouseDown(object sender, MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 size = gpu.GetScreenSize_JR();
             }
@@ -1204,7 +1204,7 @@ namespace FoenixIDE.UI
         private void GenerateMouseInterrupt(MouseEventArgs e)
         {
             Point size = gpu.GetScreenSize();
-            if (BoardVersionHelpers.IsJr(version))
+            if (BoardVersionHelpers.IsF256(version))
             {
                 gpu.GetScreenSize_JR();
             }
@@ -1233,7 +1233,7 @@ namespace FoenixIDE.UI
             left = false;
             right = false;
             middle = false;
-            if (!BoardVersionHelpers.IsJr(version) && gpu.IsMousePointerVisible() || gpu.TileEditorMode)
+            if (!BoardVersionHelpers.IsF256(version) && gpu.IsMousePointerVisible() || gpu.TileEditorMode)
             {
                 Cursor.Show();
             }
@@ -1242,7 +1242,7 @@ namespace FoenixIDE.UI
 
         private void Gpu_MouseEnter(object sender, EventArgs e)
         {
-            if (!BoardVersionHelpers.IsJr(version) && gpu.IsMousePointerVisible() && !gpu.TileEditorMode)
+            if (!BoardVersionHelpers.IsF256(version) && gpu.IsMousePointerVisible() && !gpu.TileEditorMode)
             {
                 Cursor.Hide();
             }
@@ -1477,7 +1477,7 @@ namespace FoenixIDE.UI
 
         private void SetDipSwitchMemory()
         {
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 // if kernel memory is available, set the memory
                 byte bootMode = (byte)((switches[0] ? 0 : 1) + (switches[1] ? 0 : 2));
@@ -1541,7 +1541,7 @@ namespace FoenixIDE.UI
 
         public void WriteMCRBytesToVicky(byte low, byte high)
         {
-            int baseAddr = BoardVersionHelpers.IsJr(version) ? 0xD000 - 0xC000 : 0;
+            int baseAddr = BoardVersionHelpers.IsF256(version) ? 0xD000 - 0xC000 : 0;
 
             kernel.MemMgr.VICKY.WriteByte(baseAddr, low);
             kernel.MemMgr.VICKY.WriteByte(baseAddr + 1, high);
@@ -1549,12 +1549,12 @@ namespace FoenixIDE.UI
 
         public ushort ReadMCRBytesFromVicky()
         {
-            return (ushort)kernel.MemMgr.VICKY.ReadWord(BoardVersionHelpers.IsJr(version) ? 0xD000 - 0xC000 : 0);
+            return (ushort)kernel.MemMgr.VICKY.ReadWord(BoardVersionHelpers.IsF256(version) ? 0xD000 - 0xC000 : 0);
         }
 
         public void UpdateGamma(bool gamma)
         {
-            if (!BoardVersionHelpers.IsJr(version))
+            if (!BoardVersionHelpers.IsF256(version))
             {
                 switches[6] = gamma;
                 dipSwitch.Invalidate();

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -101,6 +101,14 @@ namespace FoenixIDE.UI
                     {
                         version = BoardVersion.RevJr_65816;
                     }
+                    else if (context["version"] == "RevF256K")
+                    {
+                        version = BoardVersion.RevF256K_6502;
+                    }
+                    else if (context["version"] == "RevF256K816")
+                    {
+                        version = BoardVersion.RevF256K_65816;
+                    }
                     boardVersionCommandLineSpecified = true;
                 }
             }
@@ -131,6 +139,12 @@ namespace FoenixIDE.UI
                     case "Jr(816)":
                         version = BoardVersion.RevJr_65816;
                         break;
+                    case "F256K":
+                        version = BoardVersion.RevF256K_6502;
+                        break;
+                    case "F256K(816)":
+                        version = BoardVersion.RevF256K_65816;
+                        break;
                 }
             }
             if (defaultKernel == null)
@@ -151,7 +165,9 @@ namespace FoenixIDE.UI
                         defaultKernel = Path.Combine(romsDir, "kernel_U_Plus.hex");
                         break;
                     case BoardVersion.RevJr_6502:
-                    case BoardVersion.RevJr_65816: // Both SKUs share the same kernelfile
+                    case BoardVersion.RevJr_65816:
+                    case BoardVersion.RevF256K_6502:
+                    case BoardVersion.RevF256K_65816:// All SKUs share the same kernelfile currently
                         defaultKernel = Path.Combine(romsDir, "kernel_F256jr.hex");
                         break;
                 }
@@ -1351,6 +1367,16 @@ namespace FoenixIDE.UI
                 toolStripRevision.Text = "Rev F256Jr(816)";
                 shortVersion = "Jr(816)";
             }
+            else if (version == BoardVersion.RevF256K_6502)
+            {
+                toolStripRevision.Text = "Rev F256K";
+                shortVersion = "F256K";
+            }
+            else if (version == BoardVersion.RevF256K_65816)
+            {
+                toolStripRevision.Text = "Rev F256K(816)";
+                shortVersion = "F256K(816)";
+            }
 
             // force repaint
             statusStrip1.Invalidate();
@@ -1390,6 +1416,16 @@ namespace FoenixIDE.UI
             else if (e.ClickedItem == revJr816ToolStripMenuItem)
             {
                 version = BoardVersion.RevJr_65816;
+                defaultKernel += Path.Combine("roms", "kernel_F256jr.hex");
+            }
+            else if (e.ClickedItem == revF256KToolStripMenuItem)
+            {
+                version = BoardVersion.RevF256K_6502;
+                defaultKernel += Path.Combine("roms", "kernel_F256jr.hex");
+            }
+            else if (e.ClickedItem == revF256K816ToolStripMenuItem)
+            {
+                version = BoardVersion.RevF256K_65816;
                 defaultKernel += Path.Combine("roms", "kernel_F256jr.hex");
             }
 

--- a/Main/UI/UploaderWindow.cs
+++ b/Main/UI/UploaderWindow.cs
@@ -271,7 +271,7 @@ namespace FoenixIDE.UI
             {
                 BaseBankAddress = 0x18_0000;
             }
-            else if (BoardVersionHelpers.IsJr(boardVersion))
+            else if (BoardVersionHelpers.IsF256(boardVersion))
             {
                 BaseBankAddress = 0;
             }
@@ -785,7 +785,7 @@ namespace FoenixIDE.UI
             // Maximum transmission size is 8192
             if (Size > 8192)
             {
-                if (!BoardVersionHelpers.IsJr(boardVersion))
+                if (!BoardVersionHelpers.IsF256(boardVersion))
                 {
                     Size = 8192;
                     Console.WriteLine("PreparePacket2Write: output truncated to 8K bytes.");

--- a/Main/UI/UploaderWindow.cs
+++ b/Main/UI/UploaderWindow.cs
@@ -47,6 +47,12 @@ namespace FoenixIDE.UI
                 case BoardVersion.RevJr_65816:
                     RevModeLabel.Text = "Mode: F256Jr(816)";
                     break;
+                case BoardVersion.RevF256K_6502:
+                    RevModeLabel.Text = "Mode: F256K";
+                    break;
+                case BoardVersion.RevF256K_65816:
+                    RevModeLabel.Text = "Mode: F256K(816)";
+                    break;
             }
         }
 


### PR DESCRIPTION
Until now, the community has been testing F256 keyboard support using a hacked-up microkernel. Hacks in general are not good (these hacks aren't in kernel main), and it also means that the community can't benefit from kernel updates.

This change unblocks F256K keyboard emulation for the latest kernel. To do this, it adds two things:

1. **Explicit, separate board modes for F256 Jr and F256K that return the right Machine ID.** The kernel, on boot, reads the "Machine ID" reg 0xD6A7 to differentiate Jr from K.  You'll get misbehavior if the kernel takes the wrong path for your "hardware". So it is best to fix this by having separate explicit board modes which report their machine ID truthfully. Without this change, the kernel would never initialize the matrix keyboard because it thought the computer was a Jr and not a K.

2. **Returning empty PS2 queue for F256K.** Although C256 and F256 all support PS2 keyboards, the interface is different. C256 uses Mode 1 and F256 uses Mode 2. Mode 2 is not currently implemented in FoenixIDE. Until Mode 2 has proper support, it should return an empty queue to the kernel, so that the kernel does not mistakenly think that there is some PS2 input. Without this change, the signal for PS2 input is always fixed to 'on', so the kernel would spin indefinitely waiting for the input to finish.

![image](https://github.com/Trinity-11/FoenixIDE/assets/8118775/b59fb007-c440-4300-988e-461099c47628)
