### PR TITLE
Made scaling choices pixel perfect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Tests/*.lst
 bin/Debug
 bin/Release
 packages
+UpgradeLog.htm

--- a/Main/Display/Gpu.cs
+++ b/Main/Display/Gpu.cs
@@ -36,8 +36,11 @@ namespace FoenixIDE.Display
         private static readonly int[] vs = new int[256 * 8];
         private int[] lutCache = vs;
 
+
+        //NativeHeight and NativeWidth are no longer used in this fork proposition
         public const int NativeHeight = 480;
-        public const int NativeWidth = 768;
+        public const int NativeWidth = 640;
+
         private int MarginHeight;
         private int MarginWidth;
 
@@ -85,10 +88,10 @@ namespace FoenixIDE.Display
             ParentForm.Width = viewWidth + MarginWidth;
         }
 
-        public void SetViewScaling(float scaling)
+        public void SetViewScaling(float scaling, int requiredWidth, int requiredHeight)
         {
-            int viewHeight = (int)Math.Ceiling((float)NativeHeight * scaling);
-            int viewWidth = (int)Math.Ceiling((float)NativeWidth * scaling);
+            int viewHeight = (int)((float)requiredHeight * scaling);
+            int viewWidth = (int)((float)requiredWidth * scaling);
 
             ParentForm.Height = viewHeight + MarginHeight;
             ParentForm.Width = viewWidth + MarginWidth;

--- a/Main/UI/MainWindow.Designer.cs
+++ b/Main/UI/MainWindow.Designer.cs
@@ -63,9 +63,16 @@ namespace FoenixIDE.UI
             this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.autorunEmulatorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.viewScalingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.scale1_0XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.scale1_5XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.scale2_0XToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resolution_label_640x480MenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scalingseparator1MenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.scale1_0X_H480ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale1_5X_H480ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale2_0X_H480ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.resolution_label_640x400MenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scalingseparator2MenuItem = new System.Windows.Forms.ToolStripSeparator();
+            this.scale1_0X_H400ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale1_5X_H400ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scale2_0X_H400ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.windowsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.terminalToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.cPUToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -385,36 +392,89 @@ namespace FoenixIDE.UI
             // viewScalingToolStripMenuItem
             // 
             this.viewScalingToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.scale1_0XToolStripMenuItem,
-            this.scale1_5XToolStripMenuItem,
-            this.scale2_0XToolStripMenuItem});
+            this.resolution_label_640x480MenuItem,
+            this.scalingseparator1MenuItem,
+            this.scale1_0X_H480ToolStripMenuItem,
+            this.scale1_5X_H480ToolStripMenuItem,
+            this.scale2_0X_H480ToolStripMenuItem,
+            this.resolution_label_640x400MenuItem,
+            this.scalingseparator2MenuItem,
+            this.scale1_0X_H400ToolStripMenuItem,
+            this.scale1_5X_H400ToolStripMenuItem,
+            this.scale2_0X_H400ToolStripMenuItem});
             this.viewScalingToolStripMenuItem.Name = "viewScalingToolStripMenuItem";
             this.viewScalingToolStripMenuItem.Size = new System.Drawing.Size(169, 22);
             this.viewScalingToolStripMenuItem.Text = "View Scaling";
+            //
+            // Disabled Menu Text entry to specify 640x480
+            //
+            this.resolution_label_640x480MenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.resolution_label_640x480MenuItem.Name = "resolution_label_640x480MenuItem";
+            this.resolution_label_640x480MenuItem.Size = new System.Drawing.Size(126, 22);
+            this.resolution_label_640x480MenuItem.Text = "640 x 480";
+            this.resolution_label_640x480MenuItem.Enabled = false;
+            //
+            // Disabled Menu Text entry to specify 640x400 
+            //
+            this.resolution_label_640x400MenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.resolution_label_640x400MenuItem.Name = "resolution_label_640x400MenuItem";
+            this.resolution_label_640x400MenuItem.Size = new System.Drawing.Size(126, 22);
+            this.resolution_label_640x400MenuItem.Text = "640 x 400";
+            this.resolution_label_640x400MenuItem.Enabled = false;
             // 
-            // scale1_0XToolStripMenuItem
+            // scale1_0X_H480ToolStripMenuItem 
+            // 640x480 at 1x
             // 
-            this.scale1_0XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.scale1_0XToolStripMenuItem.Name = "scale1_0XToolStripMenuItem";
-            this.scale1_0XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
-            this.scale1_0XToolStripMenuItem.Text = "Scale 1.0X";
-            this.scale1_0XToolStripMenuItem.Click += new System.EventHandler(this.scale1_0XToolStripMenuItem_Click);
+            this.scale1_0X_H480ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_0X_H480ToolStripMenuItem.Name = "scale1_0X_H480ToolStripMenuItem";
+            this.scale1_0X_H480ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_0X_H480ToolStripMenuItem.Text = "Scale 1.0X";
+            this.scale1_0X_H480ToolStripMenuItem.Click += new System.EventHandler(this.scale1_0X_H480ToolStripMenuItem_Click);
             // 
-            // scale1_5XToolStripMenuItem
+            // scale1_5X_H480ToolStripMenuItem
+            // 640x480 at 1.5x
             // 
-            this.scale1_5XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.scale1_5XToolStripMenuItem.Name = "scale1_5XToolStripMenuItem";
-            this.scale1_5XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
-            this.scale1_5XToolStripMenuItem.Text = "Scale 1.5X";
-            this.scale1_5XToolStripMenuItem.Click += new System.EventHandler(this.scale1_5XToolStripMenuItem_Click);
+            this.scale1_5X_H480ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_5X_H480ToolStripMenuItem.Name = "scale1_5X_H480ToolStripMenuItem";
+            this.scale1_5X_H480ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_5X_H480ToolStripMenuItem.Text = "Scale 1.5X";
+            this.scale1_5X_H480ToolStripMenuItem.Click += new System.EventHandler(this.scale1_5X_H480ToolStripMenuItem_Click);
             // 
-            // scale2_0XToolStripMenuItem
+            // scale2_0X_H480ToolStripMenuItem
+            // 640x480 at 2x
             // 
-            this.scale2_0XToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
-            this.scale2_0XToolStripMenuItem.Name = "scale2_0XToolStripMenuItem";
-            this.scale2_0XToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
-            this.scale2_0XToolStripMenuItem.Text = "Scale 2.0X";
-            this.scale2_0XToolStripMenuItem.Click += new System.EventHandler(this.scale2_0XToolStripMenuItem_Click);
+            this.scale2_0X_H480ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale2_0X_H480ToolStripMenuItem.Name = "scale2_0X_H480ToolStripMenuItem";
+            this.scale2_0X_H480ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale2_0X_H480ToolStripMenuItem.Text = "Scale 2.0X";
+            this.scale2_0X_H480ToolStripMenuItem.Click += new System.EventHandler(this.scale2_0X_H480ToolStripMenuItem_Click);
+                        // 
+            // scale1_0X_H400ToolStripMenuItem 
+            // 640x400 at 1x
+            // 
+            this.scale1_0X_H400ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_0X_H400ToolStripMenuItem.Name = "scale1_0X_H400ToolStripMenuItem";
+            this.scale1_0X_H400ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_0X_H400ToolStripMenuItem.Text = "Scale 1.0X";
+            this.scale1_0X_H400ToolStripMenuItem.Click += new System.EventHandler(this.scale1_0X_H400ToolStripMenuItem_Click);
+            // 
+            // scale1_5X_H400ToolStripMenuItem
+            // 640x400 at 1.5x
+            // 
+            this.scale1_5X_H400ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale1_5X_H400ToolStripMenuItem.Name = "scale1_5X_H400ToolStripMenuItem";
+            this.scale1_5X_H400ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale1_5X_H400ToolStripMenuItem.Text = "Scale 1.5X";
+            this.scale1_5X_H400ToolStripMenuItem.Click += new System.EventHandler(this.scale1_5X_H400ToolStripMenuItem_Click);
+            // 
+            // scale2_0X_H400ToolStripMenuItem
+            // 640x400 at 2x
+            // 
+            this.scale2_0X_H400ToolStripMenuItem.ImageScaling = System.Windows.Forms.ToolStripItemImageScaling.None;
+            this.scale2_0X_H400ToolStripMenuItem.Name = "scale2_0X_H400ToolStripMenuItem";
+            this.scale2_0X_H400ToolStripMenuItem.Size = new System.Drawing.Size(126, 22);
+            this.scale2_0X_H400ToolStripMenuItem.Text = "Scale 2.0X";
+            this.scale2_0X_H400ToolStripMenuItem.Click += new System.EventHandler(this.scale2_0X_H400ToolStripMenuItem_Click);
             // 
             // windowsToolStripMenuItem
             // 
@@ -663,9 +723,16 @@ namespace FoenixIDE.UI
         private System.Windows.Forms.ToolStripMenuItem convertHexToPGZToolStripMenuItem;
         public Gpu gpu;
         private System.Windows.Forms.ToolStripMenuItem viewScalingToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem scale1_0XToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem scale2_0XToolStripMenuItem;
-        private System.Windows.Forms.ToolStripMenuItem scale1_5XToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator scalingseparator1MenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resolution_label_640x480MenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_0X_H480ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale2_0X_H480ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_5X_H480ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem resolution_label_640x400MenuItem;
+        private System.Windows.Forms.ToolStripSeparator scalingseparator2MenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_0X_H400ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale2_0X_H400ToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem scale1_5X_H400ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revJr816ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revJrToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem revUPlusToolStripMenuItem;

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -1862,22 +1862,40 @@ namespace FoenixIDE.UI
             midiForm.Show();
         }
 
-        private void scale1_0XToolStripMenuItem_Click(object sender, EventArgs e)
+        private void scale1_0X_H480ToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.WindowState = FormWindowState.Normal;
-            gpu.SetViewScaling(1.0f);
+            gpu.SetViewScaling(1.0f, 640, 480);
         }
 
-        private void scale1_5XToolStripMenuItem_Click(object sender, EventArgs e)
+        private void scale1_5X_H480ToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.WindowState = FormWindowState.Normal;
-            gpu.SetViewScaling(1.5f);
+            gpu.SetViewScaling(1.5f, 640, 480);
         }
 
-        private void scale2_0XToolStripMenuItem_Click(object sender, EventArgs e)
+        private void scale2_0X_H480ToolStripMenuItem_Click(object sender, EventArgs e)
         {
             this.WindowState = FormWindowState.Normal;
-            gpu.SetViewScaling(2.0f);
+            gpu.SetViewScaling(2.0f, 640, 480);
+        }
+
+        private void scale1_0X_H400ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.WindowState = FormWindowState.Normal;
+            gpu.SetViewScaling(1.0f, 640, 400);
+        }
+
+        private void scale1_5X_H400ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.WindowState = FormWindowState.Normal;
+            gpu.SetViewScaling(1.5f, 640, 400);
+        }
+
+        private void scale2_0X_H400ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            this.WindowState = FormWindowState.Normal;
+            gpu.SetViewScaling(2.0f, 640, 400);
         }
     }
 }


### PR DESCRIPTION
Manual resizing was always going to create a badly non-pixel perfect stretched image. Hence the scaling options in the Settings Menu. Even so, the choices were slightly off and would show stretched images and characters.

I fixed it for:
320x240 works at 1.0x, 1.5x, 2.0x
320x200 (70Hz mode) works at 1.0x, 1.5x, 2.0x (those last 3 are all-new options; 70Hz mode is achieved on a F256 by setting bit 0 of $D001 to 1)

by changing the NativeHeight and NativeWidth in the gpu.cs class, to be compatible with expectations of Form window width and height (it expects 639x479 to deal with 640 pixels by 480 pixels.

I lowered the minimal achieved gpu container size to all these perfect scalings to exist. The final solution will still allow a manual click-drag resizing that in all likelihood, will settle on a badly stretched Form size choice. Pixel Perfection can be restored by going back to Settings/Scaling options once again.