### PR TITLE
Fixed crash when the user removes a sdcard directory or file...

### DIFF
--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -1298,6 +1298,11 @@ namespace FoenixIDE.UI
             string fsType = Simulator.Properties.Settings.Default.SDCardFSType;
             bool ISOMode = Simulator.Properties.Settings.Default.SDCardISOMode;
 
+            if ((ISOMode && !File.Exists(path)) || (!ISOMode && !Directory.Exists(path)))
+            {
+                path = null;
+            }
+
             kernel.MemMgr.SDCARD.SetSDCardPath(path);
             byte sdCardStat = 0;
             if (path == null || path.Length == 0)


### PR DESCRIPTION
...in between runs.

To reproduce:
- run FoenixIDE
- select an SD card image or directory
- exit FoenixIDE
- remove SD card image or directory
- run FoenixIDE again
-> crash (at least on Linux)

With this small patch, it will just default to "SD Card Disabled".