### PR TITLE
Map Oem8 to Foenix key

### DIFF
--- a/Main/Basic/ScanCodesSet.cs
+++ b/Main/Basic/ScanCodesSet.cs
@@ -207,6 +207,7 @@ namespace FoenixIDE.Basic
                 case Keys.Escape:
                     result[0] =  sc1_escape;
                     break;
+                case Keys.Oem8:
                 case Keys.Oem3: // back tick
                     result[0] =  sc1_grave;
                     break;


### PR DESCRIPTION
Added Keys.Oem8 to enable Foenix key on non-US keyboards