### PR TITLE
Fix problem where new breakpoints don't "take effect" until after you pause the debugger

### DIFF
--- a/Main/UI/CPUWindow.cs
+++ b/Main/UI/CPUWindow.cs
@@ -1257,15 +1257,11 @@ namespace FoenixIDE.UI
 
         private void BreakpointButton_Click(object sender, EventArgs e)
         {
-            if (!breakpointWindow.Visible)
-            {
-                CenterForm(breakpointWindow);
-                breakpointWindow.Show();
-            }
-            else
-            {
-                breakpointWindow.BringToFront();
-            }
+            Pause();
+
+            CenterForm(breakpointWindow);
+
+            breakpointWindow.ShowDialog();
         }
 
         // This is called when new code is loaded in the Main Window.


### PR DESCRIPTION
I saw this misbehavior

1. Be running some program
2. Open the "Breakpoints" menu
3. Type in a breakpoint address that you know is being executed
4. Close the menu

Expected: Program immediately breaks
Actual: Program doesn't break. Reason: new breakpoints don't "take effect" until you pause execution

Proposed fix: make the "Breakpoints" menu pause the debugger for you. This is consistent with other debuggers I've used in the past. To make this effective, the dialog has to be modal, so the fix includes that.

I vetted the idea for fixing this with another user xDraconian in the Discord channel.