### PR TITLE
Don't let the user "add watch" on an invisible element

### DIFF
--- a/Main/UI/CPUWindow.cs
+++ b/Main/UI/CPUWindow.cs
@@ -1205,6 +1205,9 @@ namespace FoenixIDE.UI
 
         private void DebugPanel_MouseClick(object sender, MouseEventArgs e)
         {
+            if (!kernel.CPU.DebugPause)
+                return;
+
             // TODO: remove the reference to kernel.lstFile and replace with codeList.
             DebugLine line = SourceCodeListingFind(ActiveLine[0]);
             if (e.Button == MouseButtons.Left && ActiveLine[0] != 0 && line != null)
@@ -1222,7 +1225,7 @@ namespace FoenixIDE.UI
                     MainWindow.Instance.WatchListToolStripMenuItem_Click(sender, e);
                 }
             }
-            else if (e.Button == MouseButtons.Right && kernel.CPU.DebugPause)
+            else if (e.Button == MouseButtons.Right)
             {
                 Point contextMenuLocation = DebugPanel.PointToScreen(new Point(e.X, e.Y));
                 debugWindowContextMenuStrip.Show(contextMenuLocation);


### PR DESCRIPTION
This change fixes a bug demonstrated here: [YouTube link](https://www.youtube.com/watch?v=VeP9EZkKcOw)

1. Run a program
2. Open the Watch window
3. Pause execution
4. Click some address to add it as a Watch
5. Delete the item
6. Run execution
7. Observe that since the program is running, the CPU window is blank. 
8. Click on the blank CPU window

Expected: Nothing happens
Actual: A new watched item is mysteriously added

Explanation: The "Add new watched item" logic takes effect whenever you left click the CPU window and something was left in the ActiveLine buffer. Typically, the ActiveLine buffer contains "whatever your mouse is hovering over" as you're looking at source code. But if execution is running, you're not looking at any source code, so whatever's in ActiveLine doesn't apply.


