### PR TITLE
Add --exec-breakpoint command line option for adding a breakpoint on launch

### DIFF
--- a/Main/Program.cs
+++ b/Main/Program.cs
@@ -97,6 +97,24 @@ namespace FoenixIDE
                     case "--irq":
                         context.Add("disabledIRQs", "true");
                         break;
+                    case "-x":
+                    case "--exec-breakpoint":
+                        {
+                            string addressArg = args[i + 1];
+
+                            int addressValue = Convert.ToInt32(addressArg.Replace("$:", ""), 16);
+                            if (addressValue != 0)
+                            {
+                                context.Add("executionBreakpointAddressAtStartup", addressValue.ToString());
+                                i++; // skip the next argument
+                            }
+                            else
+                            {
+                                Console.Out.WriteLine("Invalid address specified: " + args[i + 1]);
+                                context["Continue"] = "false";
+                            }
+                            break;
+                        }
                     // Board Version B, C, U, U+, Jr, Jr816
                     case "-b":
                     case "--board":
@@ -176,6 +194,7 @@ namespace FoenixIDE
             Console.Out.WriteLine("   -j, --jump: jump to specified address");
             Console.Out.WriteLine("   -r, --run: autorun true/false");
             Console.Out.WriteLine("   -i, --irq: disable IRQs true/false");
+            Console.Out.WriteLine("   -x, --exec-breakpoint: address, in hex, at which to put an execution breakpoint");
             Console.Out.WriteLine("   -b, --board: board revision b, c, u, u+, jr, jr816");
             Console.Out.WriteLine("   -h, --help, /?: show this usage");
             Console.Out.WriteLine("   -v, --version: show the version");

--- a/Main/UI/CPUWindow.cs
+++ b/Main/UI/CPUWindow.cs
@@ -621,6 +621,16 @@ namespace FoenixIDE.UI
             MainWindow.Instance.ResetGPU(false);
         }
 
+        public void AddExecutionBreakpointProgrammatically(int address)
+        {
+            breakpointWindow.AddBreakpoint(address);
+
+            if (!knl_breakpointsExec.Contains(address))
+            {
+                knl_breakpointsExec.Add(address);
+            }
+        }
+
         private void addBreakpoints()
         {
             List<int> execs = breakpointWindow.GetExecuteBreakpoints();

--- a/Main/UI/MainWindow.cs
+++ b/Main/UI/MainWindow.cs
@@ -42,6 +42,7 @@ namespace FoenixIDE.UI
         private String defaultKernel;
         private int jumpStartAddress;
         private bool disabledIRQs = false;
+        private int executionBreakpointAddressAtStartup;
         private bool autoRun = true;
         private BoardVersion version = BoardVersion.RevC;
         public static MainWindow Instance = null;
@@ -73,6 +74,10 @@ namespace FoenixIDE.UI
                 if (context.ContainsKey("disabledIRQs"))
                 {
                     disabledIRQs = "true".Equals(context["disabledIRQs"]);
+                }
+                if (context.ContainsKey("executionBreakpointAddressAtStartup"))
+                {
+                    executionBreakpointAddressAtStartup = int.Parse(context["executionBreakpointAddressAtStartup"]);
                 }
                 if (context.ContainsKey("version"))
                 {
@@ -313,6 +318,10 @@ namespace FoenixIDE.UI
             {
                 debugWindow.locationInput.Text = jumpStartAddress.ToString("X6");
                 debugWindow.JumpButton_Click(null, null);
+            }
+            if (executionBreakpointAddressAtStartup != 0)
+            {
+                debugWindow.AddExecutionBreakpointProgrammatically(executionBreakpointAddressAtStartup);
             }
             if (autoRun)
             {


### PR DESCRIPTION
For some debugging scenarios, the interesting operation is during kernel load, where the moment passes quickly and you don't have time to click and set a breakpoint in the UI.

For that workflow, it's:
1. Launch the emulator with the specified kernel
2. Set a breakpoint in the debugger (although it won't hit now, because it's too late)
3. Restart the kernel to run it again
4. Breakpoint hits

With this command line option, it's a lot easier:
1. Launch the emulator with the specified kernel and breakpoint option
2. Kernel launches and breakpoint hits

This can also benefit other scenarios where the user has to iterate frequently and run the program under debugger many times, and there's a time savings in not having to go through the UI each time.

This is geared toward execution breakpoints since that's the most common type of breakpoint.